### PR TITLE
Fix release workflow resilience and rate limiting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests (excluding CGO packages)
         run: task test-nocgo
@@ -82,6 +83,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify compilation (pure Go packages)
         run: task build-nocgo
@@ -97,6 +99,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to ghcr.io
         uses: docker/login-action@v3
@@ -125,6 +128,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install libkrun
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to ghcr.io
         uses: docker/login-action@v3
@@ -81,6 +82,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install libkrun via Homebrew
         run: |
@@ -112,6 +114,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [build-artifacts, build-artifacts-darwin]
+    if: ${{ always() && needs.build-artifacts.result == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -125,18 +128,17 @@ jobs:
         run: |
           sha256sum propolis-*.tar.gz > sha256sums.txt
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }} --generate-notes \
-            propolis-runtime-linux-amd64.tar.gz \
-            propolis-runtime-linux-arm64.tar.gz \
-            propolis-firmware-linux-amd64.tar.gz \
-            propolis-firmware-linux-arm64.tar.gz \
-            propolis-runtime-darwin-arm64.tar.gz \
-            propolis-firmware-darwin-arm64.tar.gz \
-            sha256sums.txt
+          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            gh release upload "${{ github.ref_name }}" --clobber \
+              propolis-*.tar.gz sha256sums.txt
+          else
+            gh release create "${{ github.ref_name }}" --generate-notes \
+              propolis-*.tar.gz sha256sums.txt
+          fi
 
   push-oci:
     name: Push OCI (${{ matrix.arch }})


### PR DESCRIPTION
## Summary

The v0.0.7 release has **zero assets** because the release workflow failed partway through:

1. **`build-artifacts-darwin` failed** — `arduino/setup-task@v2` hit a GitHub API rate limit on the shared macOS runner IP (`13.105.117.192`). The action makes unauthenticated API calls by default, which have very low rate limits on shared IPs.
2. **`create-release` was skipped entirely** — it has `needs: [build-artifacts, build-artifacts-darwin]`, so when macOS failed, no release assets were uploaded despite Linux builds succeeding.
3. **Hard-coded asset list** — `gh release create` listed all 6 platform tarballs explicitly, so it would also fail if any single platform was missing.

### Fixes

- **`repo-token`**: Pass `${{ secrets.GITHUB_TOKEN }}` to all `arduino/setup-task@v2` invocations (both CI and release workflows) for authenticated API access with much higher rate limits
- **`if: always()`**: `create-release` now runs as long as the Linux builds succeed, even if macOS fails. Linux artifacts will still be released.
- **Glob + create-or-upload**: The release step uses `propolis-*.tar.gz` (shell glob) instead of hard-coded filenames. If the release already exists (e.g., created via UI), it uploads assets with `--clobber` instead of failing on `gh release create`.

## Test plan

- [ ] Merge this PR
- [ ] Re-run the v0.0.7 release workflow (run ID `22623937048`) to attach assets to the existing release
- [ ] Verify `gh release view v0.0.7 --repo stacklok/propolis --json assets` shows the expected tarballs

🤖 Generated with [Claude Code](https://claude.com/claude-code)