### PR TITLE
Add DYLD environment variables entitlement for macOS

### DIFF
--- a/assets/entitlements.plist
+++ b/assets/entitlements.plist
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
macOS strips DYLD_LIBRARY_PATH from hardened runtime processes.
The runner binary requires the hypervisor entitlement, which
enables hardened runtime, causing macOS to silently strip
DYLD_LIBRARY_PATH before the process starts. This prevents
libkrun from finding libkrunfw.dylib when it lives in a
separate firmware directory.

Add `com.apple.security.cs.allow-dyld-environment-variables` to
the runner entitlements so DYLD_LIBRARY_PATH passes through.

Verify with:
  task build-dev-darwin
  codesign -d --entitlements - bin/propolis-runner

Expected output includes:
```
  [Key] com.apple.security.cs.allow-dyld-environment-variables
  [Value]
      [Bool] true
```

I was able to boot an image with this patch:
```
DYLD_LIBRARY_PATH=/opt/homebrew/lib bin/propolis-runner "$(cat /tmp/propolis-test.json)"
 [2026-03-05T11:04:22Z DEBUG vmm::macos::vstate] Guest memory
 host_addr=0x300000000 guest_addr=80000000 len=80000000
 [2026-03-05T11:04:22Z DEBUG vmm::macos::vstate] Guest memory
 host_addr=0x380000000 guest_addr=140000000 len=20000000
 [2026-03-05T11:04:22Z DEBUG utils::macos::epoll] EpollEvent new: 4
 [2026-03-05T11:04:22Z DEBUG utils::macos::epoll] EpollEvent data: 4
 [2026-03-05T11:04:22Z DEBUG utils::macos::epoll] add fd in: 4
 [2026-03-05T11:04:22Z DEBUG devices::legacy::aarch64::gpio]
 SET_IRQ_LINE (GPIO)=33
```
