### PR TITLE
Make guest network configuration idempotent

### DIFF
--- a/guest/netcfg/netcfg.go
+++ b/guest/netcfg/netcfg.go
@@ -35,8 +35,8 @@ func Configure(logger *slog.Logger) error {
 		return fmt.Errorf("parsing guest address: %w", err)
 	}
 
-	if err := netlink.AddrAdd(link, addr); err != nil {
-		return fmt.Errorf("adding address to eth0: %w", err)
+	if err := netlink.AddrReplace(link, addr); err != nil {
+		return fmt.Errorf("configuring address on eth0: %w", err)
 	}
 
 	if err := netlink.LinkSetUp(link); err != nil {
@@ -46,8 +46,8 @@ func Configure(logger *slog.Logger) error {
 	route := &netlink.Route{
 		Gw: net.ParseIP(topology.GatewayIP),
 	}
-	if err := netlink.RouteAdd(route); err != nil {
-		return fmt.Errorf("adding default route: %w", err)
+	if err := netlink.RouteReplace(route); err != nil {
+		return fmt.Errorf("configuring default route: %w", err)
 	}
 
 	if err := os.WriteFile("/etc/resolv.conf", []byte("nameserver "+topology.GatewayIP+"\n"), 0o644); err != nil {


### PR DESCRIPTION
On macOS, libkrun's Hypervisor.framework backend pre-configures the guest network interface via DHCP before the custom init runs. When `netcfg.Configure()` calls `AddrAdd`, the kernel returns EEXIST because eth0 already has the address, causing the VM to shut down immediately.

Replace `AddrAdd/RouteAdd` with `AddrReplace/RouteReplace`. These use `NLM_F_CREATE|NLM_F_REPLACE` instead of `NLM_F_CREATE|NLM_F_EXCL`, making the operation create-if-absent or replace-if-present. This is the standard approach in CNI plugins and container runtimes.

Safe on Linux (KVM) where eth0 starts unconfigured — `NLM_F_CREATE` ensures the address/route is created, matching current behavior.

Fixes #22