### PR TITLE
Use versioned dylib names on macOS

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -24,6 +24,10 @@ vars:
     sh: grep '^LIBKRUN_VERSION=' versions.env | cut -d= -f2
   LIBKRUN_MAJOR:
     sh: grep '^LIBKRUN_VERSION=' versions.env | cut -d= -f2 | sed 's/^v//' | cut -d. -f1
+  LIBKRUNFW_VERSION:
+    sh: grep '^LIBKRUNFW_VERSION=' versions.env | cut -d= -f2
+  LIBKRUNFW_MAJOR:
+    sh: grep '^LIBKRUNFW_VERSION=' versions.env | cut -d= -f2 | sed 's/^v//' | cut -d. -f1
   BUILDER_IMAGE_TAG: '{{.LIBKRUN_VERSION}}'
 
 # Quick reference:
@@ -75,20 +79,20 @@ tasks:
     platforms: [darwin]
     cmds:
       - task: build-dev-darwin
-      - cp -f $(brew --prefix libkrun)/lib/libkrun.dylib bin/
-      - cp -f $(brew --prefix libkrunfw)/lib/libkrunfw.dylib bin/
+      - cp -f $(brew --prefix libkrun)/lib/libkrun.{{.LIBKRUN_MAJOR}}.dylib bin/
+      - cp -f $(brew --prefix libkrunfw)/lib/libkrunfw.{{.LIBKRUNFW_MAJOR}}.dylib bin/
       # Rewrite absolute Homebrew install name to @loader_path for portable bundles
       - >-
         install_name_tool -change
         /opt/homebrew/opt/libkrun/lib/libkrun.{{.LIBKRUN_MAJOR}}.dylib
-        @loader_path/libkrun.dylib
+        @loader_path/libkrun.{{.LIBKRUN_MAJOR}}.dylib
         bin/{{.RUNNER_NAME}}
       # Re-sign after binary modification (install_name_tool invalidates signature)
       - codesign --entitlements assets/entitlements.plist --force -s - bin/{{.RUNNER_NAME}}
     generates:
       - bin/{{.RUNNER_NAME}}
-      - bin/libkrun.dylib
-      - bin/libkrunfw.dylib
+      - bin/libkrun.{{.LIBKRUN_MAJOR}}.dylib
+      - bin/libkrunfw.{{.LIBKRUNFW_MAJOR}}.dylib
 
   build-dev-race:
     desc: Build runner with race detector (requires libkrun-devel)
@@ -259,7 +263,7 @@ tasks:
       - |
         staging="propolis-runtime-darwin-{{.HOST_ARCH}}"
         mkdir -p "${staging}"
-        cp bin/propolis-runner bin/libkrun.dylib "${staging}/"
+        cp bin/propolis-runner bin/libkrun.{{.LIBKRUN_MAJOR}}.dylib "${staging}/"
         echo "{{.TAG}}" > "${staging}/VERSION"
         tar czf "dist/${staging}.tar.gz" "${staging}"
         rm -rf "${staging}"
@@ -274,7 +278,7 @@ tasks:
       - |
         staging="propolis-firmware-darwin-{{.HOST_ARCH}}"
         mkdir -p "${staging}"
-        cp bin/libkrunfw.dylib "${staging}/"
+        cp bin/libkrunfw.{{.LIBKRUNFW_MAJOR}}.dylib "${staging}/"
         echo "{{.TAG}}" > "${staging}/VERSION"
         cat > "${staging}/LICENSE-GPL" <<'LICEOF'
         libkrunfw is licensed under the GNU General Public License v2.0 (GPL-2.0).

--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -26,7 +26,7 @@ automatically search both paths.
 | Aspect | Linux | macOS |
 |--------|-------|-------|
 | Hypervisor | KVM (`/dev/kvm`) | Hypervisor.framework |
-| Shared libraries | `.so` (libkrun.so.1, libkrunfw.so.5) | `.dylib` (libkrun.dylib, libkrunfw.dylib) |
+| Shared libraries | `.so` (libkrun.so.1, libkrunfw.so.5) | `.dylib` (libkrun.1.dylib, libkrunfw.5.dylib) |
 | Library path env | `LD_LIBRARY_PATH` | `DYLD_LIBRARY_PATH` |
 | Code signing | Not required | Required (hypervisor entitlement) |
 | PID identity check | `/proc/<pid>/exe` readlink | `signal(0)` best-effort |
@@ -87,9 +87,9 @@ codesign --entitlements assets/entitlements.plist --force -s - bin/propolis-runn
 ### DYLD_LIBRARY_PATH issues
 
 ```
-dyld: Library not loaded: @rpath/libkrun.dylib
+dyld: Library not loaded: @rpath/libkrun.1.dylib
 ```
 
 The runner can't find libkrun. Set `libkrun.WithLibDir()` (via
-`libkrun.NewBackend()`) to the directory containing `libkrun.dylib` and
-`libkrunfw.dylib`.
+`libkrun.NewBackend()`) to the directory containing `libkrun.1.dylib` and
+`libkrunfw.5.dylib`.

--- a/extract/libname_darwin.go
+++ b/extract/libname_darwin.go
@@ -5,6 +5,8 @@
 
 package extract
 
-func libName(base string, _ int) string {
-	return "lib" + base + ".dylib"
+import "fmt"
+
+func libName(base string, major int) string {
+	return fmt.Sprintf("lib%s.%d.dylib", base, major)
 }

--- a/extract/libname_test.go
+++ b/extract/libname_test.go
@@ -19,7 +19,7 @@ func TestLibName(t *testing.T) {
 	case "linux":
 		assert.Equal(t, "libkrun.so.1", got)
 	case "darwin":
-		assert.Equal(t, "libkrun.dylib", got)
+		assert.Equal(t, "libkrun.1.dylib", got)
 	default:
 		t.Skipf("unsupported platform: %s", runtime.GOOS)
 	}


### PR DESCRIPTION
libkrun calls dlopen("libkrunfw.5.dylib") with the versioned SONAME, but libname_darwin.go discards the major version parameter producing "libkrunfw.dylib". The dynamic linker does an exact filename match so the firmware is never found.

Include the major version in Darwin library names to match the macOS convention (lib{name}.{major}.dylib), consistent with what Homebrew ships and what libkrun expects at runtime.

Verified by overriding DYLD_FALLBACK_LIBRARY_PATH to isolate from Homebrew system install:
  - libkrunfw.5.dylib → Loads fine
  - libkrunfw.dylib   → "Couldn't find or load libkrunfw.5.dylib" (-2)

Fixes: #23 