### PR TITLE
Set explicit platform when pulling remote images

### DIFF
--- a/image/interfaces.go
+++ b/image/interfaces.go
@@ -6,6 +6,7 @@ package image
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -38,5 +39,9 @@ func (f RemoteFetcher) Pull(ctx context.Context, ref string) (v1.Image, error) {
 	return remote.Image(parsed,
 		remote.WithContext(ctx),
 		remote.WithAuthFromKeychain(kc),
+		remote.WithPlatform(v1.Platform{
+			OS:           "linux",
+			Architecture: runtime.GOARCH,
+		}),
 	)
 }


### PR DESCRIPTION
The go-containerregistry library defaults to linux/amd64 regardless of host architecture. On ARM hosts (macOS Apple Silicon, Linux arm64) this pulls the wrong image from multi-arch registries, causing the VM to fail at runtime.

Specify linux/runtime.GOARCH explicitly so the platform matches the guest CPU, which always equals the host CPU (hardware virtualization, no emulation).

Fixes #25