### PR TITLE
Set GOTOOLCHAIN=auto for builder container

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -210,6 +210,7 @@ tasks:
       - >-
         {{.CONTAINER_RUNTIME}} run --rm -v $(pwd):/src:z -w /src
         -e CGO_ENABLED=1
+        -e GOTOOLCHAIN=auto
         {{.BUILDER_IMAGE}}:{{.BUILDER_IMAGE_TAG}}
         go build -buildvcs=false -ldflags "{{.LDFLAGS}}" -o bin/{{.RUNNER_NAME}} ./runner/cmd/propolis-runner
     generates:

--- a/images/builder/Containerfile
+++ b/images/builder/Containerfile
@@ -42,6 +42,7 @@ RUN git clone --depth 1 --branch "${LIBKRUN_VERSION}" https://github.com/contain
     && sed "s|^libdir=.*|libdir=/opt/libkrun-built|" /opt/libkrun/libkrun.pc > /opt/libkrun-built/pkgconfig/libkrun.pc
 
 # Environment variables for downstream builds
+ENV GOTOOLCHAIN=auto
 ENV LIBKRUN_LIB_PATH=/opt/libkrun-built
 ENV PKG_CONFIG_PATH=/opt/libkrun-built/pkgconfig
 ENV CGO_LDFLAGS=-L/opt/libkrun-built


### PR DESCRIPTION
## Summary

- The v0.0.13 release failed because the builder container image has Go 1.25.7 (from Fedora's `dnf`) but `go.mod` now requires Go 1.26.0
- Sets `GOTOOLCHAIN=auto` in both the Containerfile and the Taskfile `podman run` invocation so Go auto-downloads the required toolchain
- The Taskfile change is an immediate fix (works with the existing image); the Containerfile change ensures future image rebuilds also have it

Fixes: https://github.com/stacklok/propolis/actions/runs/22795099737/job/66128338159

## Test plan

- [ ] CI passes (build-runner task succeeds with existing builder image)
- [ ] After merge, re-tag v0.0.13 and verify release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)