### PR TITLE
Add WithLogLevel option for libkrun log verbosity

### DIFF
--- a/hypervisor/backend.go
+++ b/hypervisor/backend.go
@@ -49,6 +49,7 @@ type VMConfig struct {
 	InitConfig       InitConfig
 	DataDir          string
 	ConsoleLogPath   string
+	LogLevel         uint32 // Hypervisor log level (0=off, 5=most verbose)
 	NetEndpoint      NetEndpoint
 }
 

--- a/hypervisor/libkrun/backend.go
+++ b/hypervisor/libkrun/backend.go
@@ -138,6 +138,7 @@ func (b *Backend) Start(ctx context.Context, cfg hypervisor.VMConfig) (hyperviso
 		PortForwards: toRunnerPortForwards(cfg.PortForwards),
 		VirtioFS:     toRunnerVirtioFS(cfg.FilesystemMounts),
 		ConsoleLog:   cfg.ConsoleLogPath,
+		LogLevel:     cfg.LogLevel,
 		LibDir:       libDir,
 		RunnerPath:   runnerPath,
 		VMLogPath:    filepath.Join(cfg.DataDir, "vm.log"),

--- a/options.go
+++ b/options.go
@@ -79,6 +79,7 @@ type config struct {
 	externalCache         bool               // true when WithImageCache was called explicitly
 	imageFetcher          image.ImageFetcher // nil = default local-then-remote fallback
 	backend               hypervisor.Backend // nil = default libkrun backend
+	logLevel              uint32             // libkrun log level (0=off, 5=trace)
 	cleanDataDir          bool
 	removeAll             func(string) error
 	stat                  func(string) (os.FileInfo, error)
@@ -289,4 +290,10 @@ func WithImageCache(cache *image.Cache) Option {
 // the Docker/Podman daemon first, then falls back to remote registry pull.
 func WithImageFetcher(f image.ImageFetcher) Option {
 	return optionFunc(func(c *config) { c.imageFetcher = f })
+}
+
+// WithLogLevel sets the libkrun log verbosity (0=off, 1=error, ..., 5=trace).
+// Logs are written to vm.log in the data directory.
+func WithLogLevel(level uint32) Option {
+	return optionFunc(func(c *config) { c.logLevel = level })
 }

--- a/propolis.go
+++ b/propolis.go
@@ -171,6 +171,7 @@ func Run(ctx context.Context, imageRef string, opts ...Option) (*VM, error) {
 		InitConfig:       initCfg,
 		DataDir:          cfg.dataDir,
 		ConsoleLogPath:   filepath.Join(cfg.dataDir, "console.log"),
+		LogLevel:         cfg.logLevel,
 		NetEndpoint:      netEndpoint,
 	}
 	handle, err := backend.Start(ctx, vmCfg)


### PR DESCRIPTION
Wire the log level setting through the full pipeline from the
public API (WithLogLevel) to the runner subprocess config. Both
runner Config structs already had the LogLevel field; this just
connects it to the top-level functional options.

Fixes #32

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
