### PR TITLE
Set override_stat xattr to fix macOS virtiofs permissions

### DIFF
--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stacklok/propolis/image"
 	"github.com/stacklok/propolis/internal/pathutil"
+	"github.com/stacklok/propolis/internal/xattr"
 )
 
 // validEnvKey matches POSIX-compliant environment variable names.
@@ -179,5 +180,8 @@ func BestEffortLchown(path string, uid, gid int) error {
 			slog.Warn("lchown failed", "path", path, "uid", uid, "gid", gid, "err", err)
 		}
 	}
+	// On macOS, set the override_stat xattr so libkrun's virtiofs reports
+	// correct ownership to the guest (non-root cannot Lchown to a different UID).
+	xattr.SetOverrideStatFromPath(path, uid, gid)
 	return nil
 }

--- a/image/pull.go
+++ b/image/pull.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/stacklok/propolis/internal/xattr"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -389,6 +390,7 @@ func copyOwnership(src, dst string) {
 		return
 	}
 	bestEffortLchown(dst, int(stat.Uid), int(stat.Gid))
+	xattr.CopyOverrideStat(src, dst)
 }
 
 // copyFileToDir copies a regular file from src to target within rootDir.
@@ -640,6 +642,13 @@ func extractTarEntry(tr *tar.Reader, hdr *tar.Header, target, rootDir string) er
 	// Best-effort ownership preservation from tar headers.
 	// When running as non-root, Lchown will fail with EPERM — that's fine.
 	bestEffortLchown(target, hdr.Uid, hdr.Gid)
+
+	// On macOS, set the override_stat xattr so libkrun's virtiofs FUSE
+	// server reports the tar entry's original ownership to the guest.
+	// Note: uid/gid/mode come from untrusted OCI tar headers and are
+	// intentionally forwarded — the guest is hardware-isolated and the
+	// image author already controls everything the guest runs.
+	xattr.SetOverrideStat(target, hdr.Uid, hdr.Gid, hdr.FileInfo().Mode())
 
 	return nil
 }

--- a/internal/xattr/doc.go
+++ b/internal/xattr/doc.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package xattr sets libkrun's user.containers.override_stat extended
+// attribute on macOS so that the virtiofs FUSE server reports correct
+// guest-visible ownership and permissions for rootfs files.
+//
+// When propolis extracts an OCI image on macOS, the host user (typically
+// uid 501) ends up owning all files because non-root cannot chown.
+// libkrun's FUSE server performs access checks against these host-side
+// attributes, causing permission denied errors for guest processes
+// running as UIDs that don't exist on the host (e.g. uid 1000).
+//
+// Setting this xattr on each file tells the FUSE server to override
+// the reported stat values, making the guest see the correct ownership
+// from the original OCI image. This is the same mechanism that podman
+// uses on macOS.
+//
+// On non-darwin platforms these functions are no-ops.
+package xattr

--- a/internal/xattr/override_darwin.go
+++ b/internal/xattr/override_darwin.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package xattr
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const overrideKey = "user.containers.override_stat"
+
+// SetOverrideStat sets the user.containers.override_stat xattr on path
+// so that libkrun's virtiofs FUSE server reports the given uid, gid,
+// and mode to the guest instead of the real APFS values.
+// Errors are logged at debug level and silently ignored.
+func SetOverrideStat(path string, uid, gid int, mode os.FileMode) {
+	unixMode := goFileModeToPosix(mode)
+	val := fmt.Sprintf("%d:%d:0%o", uid, gid, unixMode)
+	if err := unix.Lsetxattr(path, overrideKey, []byte(val), 0); err != nil {
+		slog.Debug("setxattr override_stat failed", "path", path, "err", err)
+	}
+}
+
+// SetOverrideStatFromPath sets the override_stat xattr by reading the
+// file's current mode via Lstat. Useful when you know the intended
+// uid/gid but the mode comes from the existing file on disk.
+func SetOverrideStatFromPath(path string, uid, gid int) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		slog.Debug("lstat for override_stat failed", "path", path, "err", err)
+		return
+	}
+	SetOverrideStat(path, uid, gid, info.Mode())
+}
+
+// CopyOverrideStat copies the user.containers.override_stat xattr from
+// src to dst. No-op if src has no such xattr. Errors are silently ignored.
+func CopyOverrideStat(src, dst string) {
+	buf := make([]byte, 256)
+	n, err := unix.Lgetxattr(src, overrideKey, buf)
+	if err != nil || n == 0 {
+		return
+	}
+	if err := unix.Lsetxattr(dst, overrideKey, buf[:n], 0); err != nil {
+		slog.Debug("copy override_stat xattr failed", "dst", dst, "err", err)
+	}
+}
+
+// goFileModeToPosix converts a Go os.FileMode to a POSIX st_mode value
+// including file type bits.
+func goFileModeToPosix(m os.FileMode) uint32 {
+	mode := uint32(m.Perm())
+
+	if m&os.ModeSetuid != 0 {
+		mode |= 0o4000
+	}
+	if m&os.ModeSetgid != 0 {
+		mode |= 0o2000
+	}
+	if m&os.ModeSticky != 0 {
+		mode |= 0o1000
+	}
+
+	switch {
+	case m.IsDir():
+		mode |= 0o040000 // S_IFDIR
+	case m&os.ModeSymlink != 0:
+		mode |= 0o120000 // S_IFLNK
+	case m&os.ModeNamedPipe != 0:
+		mode |= 0o010000 // S_IFIFO
+	case m&os.ModeSocket != 0:
+		mode |= 0o140000 // S_IFSOCK
+	case m&os.ModeDevice != 0:
+		if m&os.ModeCharDevice != 0 {
+			mode |= 0o020000 // S_IFCHR
+		} else {
+			mode |= 0o060000 // S_IFBLK
+		}
+	default:
+		mode |= 0o100000 // S_IFREG
+	}
+
+	return mode
+}

--- a/internal/xattr/override_darwin_test.go
+++ b/internal/xattr/override_darwin_test.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package xattr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestSetOverrideStat_RegularFile(t *testing.T) {
+	t.Parallel()
+
+	f := filepath.Join(t.TempDir(), "test.txt")
+	require.NoError(t, os.WriteFile(f, []byte("hello"), 0o644))
+
+	SetOverrideStat(f, 0, 0, 0o644)
+
+	assert.Equal(t, "0:0:0100644", readXattr(t, f))
+}
+
+func TestSetOverrideStat_ExecutableFile(t *testing.T) {
+	t.Parallel()
+
+	f := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.WriteFile(f, []byte("#!/bin/sh"), 0o755))
+
+	SetOverrideStat(f, 0, 0, 0o755)
+
+	assert.Equal(t, "0:0:0100755", readXattr(t, f))
+}
+
+func TestSetOverrideStat_Directory(t *testing.T) {
+	t.Parallel()
+
+	d := filepath.Join(t.TempDir(), "dir")
+	require.NoError(t, os.Mkdir(d, 0o755))
+
+	SetOverrideStat(d, 1000, 1000, os.ModeDir|0o755)
+
+	assert.Equal(t, "1000:1000:040755", readXattr(t, d))
+}
+
+func TestSetOverrideStat_RestrictiveMode(t *testing.T) {
+	t.Parallel()
+
+	f := filepath.Join(t.TempDir(), "secret")
+	require.NoError(t, os.WriteFile(f, []byte("secret"), 0o600))
+
+	SetOverrideStat(f, 1000, 1000, 0o600)
+
+	assert.Equal(t, "1000:1000:0100600", readXattr(t, f))
+}
+
+func TestSetOverrideStat_Symlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	require.NoError(t, os.WriteFile(target, []byte("data"), 0o644))
+	link := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink(target, link))
+
+	SetOverrideStat(link, 0, 0, os.ModeSymlink|0o777)
+
+	assert.Equal(t, "0:0:0120777", readXattr(t, link))
+}
+
+func TestSetOverrideStatFromPath(t *testing.T) {
+	t.Parallel()
+
+	f := filepath.Join(t.TempDir(), "test.sh")
+	require.NoError(t, os.WriteFile(f, []byte("#!/bin/sh"), 0o755))
+
+	SetOverrideStatFromPath(f, 0, 0)
+
+	// Mode should be read from the file (regular + 0755).
+	assert.Equal(t, "0:0:0100755", readXattr(t, f))
+}
+
+func TestCopyOverrideStat(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	require.NoError(t, os.WriteFile(src, []byte("data"), 0o644))
+	require.NoError(t, os.WriteFile(dst, []byte("data"), 0o644))
+
+	SetOverrideStat(src, 42, 42, 0o755)
+	CopyOverrideStat(src, dst)
+
+	assert.Equal(t, "42:42:0100755", readXattr(t, dst))
+}
+
+func TestCopyOverrideStat_NoXattr(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	require.NoError(t, os.WriteFile(src, []byte("data"), 0o644))
+	require.NoError(t, os.WriteFile(dst, []byte("data"), 0o644))
+
+	// No xattr on src — should be a no-op.
+	CopyOverrideStat(src, dst)
+
+	buf := make([]byte, 256)
+	_, err := unix.Lgetxattr(dst, overrideKey, buf)
+	assert.Error(t, err)
+}
+
+func TestGoFileModeToPosix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode os.FileMode
+		want uint32
+	}{
+		{"regular 644", 0o644, 0o100644},
+		{"regular 755", 0o755, 0o100755},
+		{"regular 600", 0o600, 0o100600},
+		{"dir 755", os.ModeDir | 0o755, 0o040755},
+		{"dir 700", os.ModeDir | 0o700, 0o040700},
+		{"symlink", os.ModeSymlink | 0o777, 0o120777},
+		{"setuid", os.ModeSetuid | 0o755, 0o104755},
+		{"setgid", os.ModeSetgid | 0o755, 0o102755},
+		{"sticky", os.ModeSticky | 0o755, 0o101755},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := goFileModeToPosix(tt.mode)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func readXattr(t *testing.T, path string) string {
+	t.Helper()
+	buf := make([]byte, 256)
+	n, err := unix.Lgetxattr(path, overrideKey, buf)
+	require.NoError(t, err)
+	return string(buf[:n])
+}

--- a/internal/xattr/override_other.go
+++ b/internal/xattr/override_other.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !darwin
+
+package xattr
+
+import "os"
+
+// SetOverrideStat is a no-op on non-darwin platforms.
+func SetOverrideStat(_ string, _, _ int, _ os.FileMode) {}
+
+// SetOverrideStatFromPath is a no-op on non-darwin platforms.
+func SetOverrideStatFromPath(_ string, _, _ int) {}
+
+// CopyOverrideStat is a no-op on non-darwin platforms.
+func CopyOverrideStat(_, _ string) {}

--- a/rootfs/clone.go
+++ b/rootfs/clone.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/stacklok/propolis/internal/xattr"
 )
 
 // CloneDir recursively clones srcDir into dstDir using platform-native COW
@@ -211,4 +213,5 @@ func bestEffortLchown(src, dst string) {
 		return
 	}
 	_ = os.Lchown(dst, uid, gid)
+	xattr.CopyOverrideStat(src, dst)
 }


### PR DESCRIPTION
On macOS, libkrun's virtiofs FUSE server performs access checks using host-side file ownership. Since non-root users cannot chown, extracted rootfs files are owned by the host user (uid 501), and the FUSE server denies access to guest processes running as UIDs that don't exist on the host (e.g. uid 1000).

libkrun provides the user.containers.override_stat xattr for exactly this case — podman already sets it during image extraction on macOS. We were the only libkrun consumer not using it, which is why we were the only ones hitting this bug.

Set the xattr on every file during OCI extraction, layer composition, rootfs cloning, and hook injection so the FUSE server reports the original image ownership to the guest. On Linux the calls are compile-time no-ops.

Fixes #30