### PR TITLE
Fix rootfs root directory permissions and xattr

### DIFF
--- a/image/pull.go
+++ b/image/pull.go
@@ -130,6 +130,15 @@ func PullWithFetcher(ctx context.Context, imageRef string, cache *Cache, fetcher
 		}
 	}
 
+	// Ensure the rootfs root directory itself is world-accessible and has
+	// the override_stat xattr. The root dir is created by os.MkdirTemp
+	// (mode 0700) and no tar entry covers it, so without this fix the
+	// guest's uid 1000 user cannot traverse /.
+	if err := os.Chmod(tmpDir, 0o755); err != nil {
+		slog.Warn("chmod rootfs root dir failed", "err", err)
+	}
+	xattr.SetOverrideStat(tmpDir, 0, 0, os.ModeDir|0o755)
+
 	// Move into cache if available. The extraction is fresh and this is
 	// the only reference, so FromCache stays false — callers may safely
 	// modify the rootfs in place without a COW clone.

--- a/rootfs/clone.go
+++ b/rootfs/clone.go
@@ -115,6 +115,10 @@ func CloneDir(srcDir, dstDir string) error {
 		_ = os.Chmod(dirsToRestore[i].path, dirsToRestore[i].perm)
 	}
 
+	// Copy the override_stat xattr on the root directory itself.
+	// The walk skips "." so the root dir's xattr is not covered above.
+	xattr.CopyOverrideStat(srcDir, dstDir)
+
 	return nil
 }
 


### PR DESCRIPTION
os.MkdirTemp creates the rootfs root with mode 0700 and no OCI tar entry covers it, so guest processes running as non-root (e.g. uid 1000) cannot traverse /. Chmod it to 0755 after extraction and set the override_stat xattr so libkrun reports root ownership.

Also copy the root dir's xattr in CloneDir — the walk skips "." so it was previously missed.

Fixes #39