### PR TITLE
Add Linux user namespace support for runner spawning

### DIFF
--- a/hypervisor/libkrun/backend.go
+++ b/hypervisor/libkrun/backend.go
@@ -45,14 +45,32 @@ func WithFirmware(src extract.Source) Option { return func(b *Backend) { b.firmw
 // Ignored when Sources are directory-based.
 func WithCacheDir(dir string) Option { return func(b *Backend) { b.cacheDir = dir } }
 
+// WithUserNamespaceUID configures the runner to spawn inside a Linux user
+// namespace (CLONE_NEWUSER) with a single UID/GID mapping. The child
+// process gains CAP_SETUID and CAP_SETGID within the namespace, which
+// allows libkrun's virtiofs passthrough to call set_creds() without
+// requiring host-level capabilities.
+//
+// uid and gid specify the namespace-side IDs that map to the host
+// process's real UID/GID. For example, if the guest expects UID 1000
+// and the host runs as UID 1000, pass uid=1000, gid=1000.
+//
+// On non-Linux platforms, this option is accepted but has no effect.
+func WithUserNamespaceUID(uid, gid uint32) Option {
+	return func(b *Backend) {
+		b.userNamespace = &runner.UserNamespaceConfig{UID: uid, GID: gid}
+	}
+}
+
 // Backend implements hypervisor.Backend using libkrun.
 type Backend struct {
-	runnerPath string
-	libDir     string
-	spawner    runner.Spawner
-	runtime    extract.Source
-	firmware   extract.Source
-	cacheDir   string
+	runnerPath    string
+	libDir        string
+	spawner       runner.Spawner
+	runtime       extract.Source
+	firmware      extract.Source
+	cacheDir      string
+	userNamespace *runner.UserNamespaceConfig
 }
 
 // NewBackend creates a libkrun backend with the given options.
@@ -131,17 +149,18 @@ func (b *Backend) Start(ctx context.Context, cfg hypervisor.VMConfig) (hyperviso
 	}
 
 	runCfg := runner.Config{
-		RootPath:     cfg.RootFSPath,
-		NumVCPUs:     cfg.NumVCPUs,
-		RAMMiB:       cfg.RAMMiB,
-		NetSocket:    netSocket,
-		PortForwards: toRunnerPortForwards(cfg.PortForwards),
-		VirtioFS:     toRunnerVirtioFS(cfg.FilesystemMounts),
-		ConsoleLog:   cfg.ConsoleLogPath,
-		LogLevel:     cfg.LogLevel,
-		LibDir:       libDir,
-		RunnerPath:   runnerPath,
-		VMLogPath:    filepath.Join(cfg.DataDir, "vm.log"),
+		RootPath:      cfg.RootFSPath,
+		NumVCPUs:      cfg.NumVCPUs,
+		RAMMiB:        cfg.RAMMiB,
+		NetSocket:     netSocket,
+		PortForwards:  toRunnerPortForwards(cfg.PortForwards),
+		VirtioFS:      toRunnerVirtioFS(cfg.FilesystemMounts),
+		ConsoleLog:    cfg.ConsoleLogPath,
+		LogLevel:      cfg.LogLevel,
+		LibDir:        libDir,
+		RunnerPath:    runnerPath,
+		VMLogPath:     filepath.Join(cfg.DataDir, "vm.log"),
+		UserNamespace: b.userNamespace,
 	}
 
 	spawner := b.spawner

--- a/hypervisor/libkrun/backend_test.go
+++ b/hypervisor/libkrun/backend_test.go
@@ -448,5 +448,62 @@ func TestBackend_Start_DefaultUnchanged(t *testing.T) {
 	assert.Equal(t, "/my/lib", spawner.captured.LibDir)
 }
 
+func TestBackend_Options_UserNamespaceUID(t *testing.T) {
+	t.Parallel()
+
+	b := NewBackend(WithUserNamespaceUID(1000, 1000))
+
+	require.NotNil(t, b.userNamespace)
+	assert.Equal(t, uint32(1000), b.userNamespace.UID)
+	assert.Equal(t, uint32(1000), b.userNamespace.GID)
+}
+
+func TestBackend_Start_WithUserNamespaceUID(t *testing.T) {
+	t.Parallel()
+
+	proc := &mockProcessHandle{pid: 77, alive: true}
+	spawner := &captureSpawner{proc: proc}
+
+	b := NewBackend(
+		WithUserNamespaceUID(1000, 1000),
+		WithSpawner(spawner),
+	)
+
+	cfg := hypervisor.VMConfig{
+		RootFSPath: t.TempDir(),
+		DataDir:    t.TempDir(),
+	}
+
+	handle, err := b.Start(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+
+	// Verify the user namespace config was threaded through.
+	require.NotNil(t, spawner.captured.UserNamespace)
+	assert.Equal(t, uint32(1000), spawner.captured.UserNamespace.UID)
+	assert.Equal(t, uint32(1000), spawner.captured.UserNamespace.GID)
+}
+
+func TestBackend_Start_WithoutUserNamespace(t *testing.T) {
+	t.Parallel()
+
+	proc := &mockProcessHandle{pid: 78, alive: true}
+	spawner := &captureSpawner{proc: proc}
+
+	b := NewBackend(WithSpawner(spawner))
+
+	cfg := hypervisor.VMConfig{
+		RootFSPath: t.TempDir(),
+		DataDir:    t.TempDir(),
+	}
+
+	handle, err := b.Start(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+
+	// UserNamespace should be nil when not configured.
+	assert.Nil(t, spawner.captured.UserNamespace)
+}
+
 // Verify mockSource implements extract.Source.
 var _ extract.Source = (*mockSource)(nil)

--- a/preflight/userns_linux.go
+++ b/preflight/userns_linux.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const usernsCloneSysctl = "/proc/sys/kernel/unprivileged_userns_clone"
+
+// usernsChecker holds injectable dependencies for user namespace verification.
+type usernsChecker struct {
+	getuid   func() int
+	readFile func(string) ([]byte, error)
+}
+
+func newUsernsChecker() *usernsChecker {
+	return &usernsChecker{
+		getuid:   os.Getuid,
+		readFile: os.ReadFile,
+	}
+}
+
+// check verifies that unprivileged user namespaces are available. Root
+// can always create user namespaces, so the check only applies to
+// non-root users. On kernels that don't expose the sysctl (e.g.
+// Fedora 30+, most modern distros), the check passes — CLONE_NEWUSER
+// is always available.
+func (c *usernsChecker) check(_ context.Context) error {
+	// Root can always create user namespaces.
+	if c.getuid() == 0 {
+		return nil
+	}
+
+	data, err := c.readFile(usernsCloneSysctl)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Sysctl doesn't exist — unprivileged userns is always enabled.
+			return nil
+		}
+		return fmt.Errorf("cannot read %s: %w", usernsCloneSysctl, err)
+	}
+
+	val := strings.TrimSpace(string(data))
+	if val == "0" {
+		return fmt.Errorf("unprivileged user namespaces are disabled (kernel.unprivileged_userns_clone=0); " +
+			"the runner requires CLONE_NEWUSER for virtiofs UID/GID mapping; " +
+			"enable with: sudo sysctl -w kernel.unprivileged_userns_clone=1")
+	}
+
+	return nil
+}
+
+// UserNamespaceCheck returns a preflight Check that verifies unprivileged
+// user namespaces are available. This check should only be registered when
+// user namespace spawning is configured.
+func UserNamespaceCheck() Check {
+	c := newUsernsChecker()
+	return Check{
+		Name:        "userns",
+		Description: "Verify unprivileged user namespaces are available",
+		Run:         c.check,
+		Required:    true,
+	}
+}

--- a/preflight/userns_linux_test.go
+++ b/preflight/userns_linux_test.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsernsCheck_Root(t *testing.T) {
+	t.Parallel()
+
+	c := &usernsChecker{
+		getuid: func() int { return 0 },
+		readFile: func(_ string) ([]byte, error) {
+			t.Fatal("readFile should not be called for root")
+			return nil, nil
+		},
+	}
+
+	err := c.check(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestUsernsCheck_SysctlNotExist(t *testing.T) {
+	t.Parallel()
+
+	c := &usernsChecker{
+		getuid: func() int { return 1000 },
+		readFile: func(_ string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		},
+	}
+
+	// If the sysctl doesn't exist, unprivileged userns is always enabled.
+	err := c.check(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestUsernsCheck_Enabled(t *testing.T) {
+	t.Parallel()
+
+	c := &usernsChecker{
+		getuid: func() int { return 1000 },
+		readFile: func(_ string) ([]byte, error) {
+			return []byte("1\n"), nil
+		},
+	}
+
+	err := c.check(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestUsernsCheck_Disabled(t *testing.T) {
+	t.Parallel()
+
+	c := &usernsChecker{
+		getuid: func() int { return 1000 },
+		readFile: func(_ string) ([]byte, error) {
+			return []byte("0\n"), nil
+		},
+	}
+
+	err := c.check(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unprivileged user namespaces are disabled")
+	assert.Contains(t, err.Error(), "kernel.unprivileged_userns_clone=1")
+}
+
+func TestUsernsCheck_ReadError(t *testing.T) {
+	t.Parallel()
+
+	c := &usernsChecker{
+		getuid: func() int { return 1000 },
+		readFile: func(_ string) ([]byte, error) {
+			return nil, fmt.Errorf("permission denied")
+		},
+	}
+
+	err := c.check(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot read")
+}
+
+func TestUserNamespaceCheck_ReturnsCheck(t *testing.T) {
+	t.Parallel()
+
+	check := UserNamespaceCheck()
+	assert.Equal(t, "userns", check.Name)
+	assert.True(t, check.Required)
+	assert.NotNil(t, check.Run)
+}

--- a/preflight/userns_other.go
+++ b/preflight/userns_other.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package preflight
+
+import "context"
+
+// UserNamespaceCheck returns a no-op preflight check on non-Linux platforms.
+// User namespaces are a Linux-specific feature.
+func UserNamespaceCheck() Check {
+	return Check{
+		Name:        "userns",
+		Description: "Verify unprivileged user namespaces are available (Linux only)",
+		Run:         func(_ context.Context) error { return nil },
+		Required:    false,
+	}
+}

--- a/runner/config.go
+++ b/runner/config.go
@@ -44,6 +44,11 @@ type Config struct {
 	// VMLogPath is the path to the file where runner stdout/stderr is written.
 	// Not serialized to JSON; used by Spawn to redirect output.
 	VMLogPath string `json:"-"`
+	// UserNamespace configures a Linux user namespace for the runner subprocess.
+	// When non-nil, the runner is spawned inside CLONE_NEWUSER so that
+	// libkrun's virtiofs passthrough can call set_creds() without host caps.
+	// Not serialized to JSON; applied by SpawnProcess before exec.
+	UserNamespace *UserNamespaceConfig `json:"-"`
 }
 
 // VirtioFSMount exposes a host directory to the guest via virtio-fs.

--- a/runner/spawn.go
+++ b/runner/spawn.go
@@ -116,6 +116,7 @@ func SpawnProcess(ctx context.Context, cfg Config) (*Process, error) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setsid: true, // Create new session (detach from terminal)
 	}
+	applyUserNamespace(cmd, cfg.UserNamespace)
 
 	// Set library search path for bundled libraries if available.
 	if cfg.LibDir != "" {
@@ -135,6 +136,10 @@ func SpawnProcess(ctx context.Context, cfg Config) (*Process, error) {
 	}
 
 	if err := cmd.Start(); err != nil {
+		if cfg.UserNamespace != nil && isPermissionError(err) {
+			return nil, fmt.Errorf("start runner process: %w; user namespaces may be disabled — "+
+				"check that kernel.unprivileged_userns_clone=1 (sysctl kernel.unprivileged_userns_clone)", err)
+		}
 		return nil, fmt.Errorf("start runner process: %w", err)
 	}
 
@@ -281,4 +286,11 @@ func libPathEnvVar() string {
 // isNoSuchProcess returns true if the error indicates the process does not exist.
 func isNoSuchProcess(err error) bool {
 	return errors.Is(err, syscall.ESRCH)
+}
+
+// isPermissionError returns true if the error indicates a permission denial
+// (EPERM or EINVAL, the latter being returned by some kernels when
+// CLONE_NEWUSER is disabled).
+func isPermissionError(err error) bool {
+	return errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EINVAL)
 }

--- a/runner/userns.go
+++ b/runner/userns.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+// UserNamespaceConfig configures a Linux user namespace for the runner
+// subprocess. When set, the runner is spawned inside a CLONE_NEWUSER
+// namespace so that it gains CAP_SETUID/CAP_SETGID within the namespace.
+// This allows libkrun's virtiofs passthrough to call set_creds() without
+// requiring host-level capabilities.
+//
+// The UID and GID fields specify the single mapping from container
+// namespace IDs to the host process's real UID/GID. For example, if the
+// guest expects UID 1000 and the host process runs as UID 1000, set
+// UID=1000 and GID=1000 to create the mapping 1000→1000.
+type UserNamespaceConfig struct {
+	// UID is the user ID inside the namespace that maps to the host UID.
+	UID uint32
+	// GID is the group ID inside the namespace that maps to the host GID.
+	GID uint32
+}

--- a/runner/userns_linux.go
+++ b/runner/userns_linux.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package runner
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// applyUserNamespace configures the exec.Cmd to spawn the child inside a
+// new user namespace (CLONE_NEWUSER). The child process gains all
+// capabilities within the namespace, which allows libkrun's virtiofs
+// passthrough to use set_creds() for UID/GID switching.
+//
+// A single UID and GID mapping is created from the namespace ID to the
+// host process's real UID/GID. The Go runtime handles writing uid_map,
+// gid_map, and "deny" to setgroups (required before gid_map since
+// Linux 3.19) via SysProcAttr.
+//
+// Note on libkrun's ScopedGid/ScopedUid Drop: When the RAII guard resets
+// credentials back to UID/GID 0 via setresgid(-1, 0, -1), the call
+// silently fails because GID 0 is unmapped. This is benign — the next
+// set_creds call will set correct credentials, and root operations
+// (GID 0) are skipped entirely by libkrun.
+func applyUserNamespace(cmd *exec.Cmd, ns *UserNamespaceConfig) {
+	if ns == nil {
+		return
+	}
+
+	hostUID := uint32(syscall.Getuid())
+	hostGID := uint32(syscall.Getgid())
+
+	cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWUSER
+	cmd.SysProcAttr.UidMappings = []syscall.SysProcIDMap{
+		{ContainerID: int(ns.UID), HostID: int(hostUID), Size: 1},
+	}
+	cmd.SysProcAttr.GidMappings = []syscall.SysProcIDMap{
+		{ContainerID: int(ns.GID), HostID: int(hostGID), Size: 1},
+	}
+	// Deny setgroups inside the namespace. This is required by the kernel
+	// before writing gid_map for unprivileged users (since Linux 3.19).
+	// The Go runtime writes "deny" to /proc/<pid>/setgroups automatically
+	// when GidMappingsEnableSetgroups is false (the zero value).
+}

--- a/runner/userns_linux_test.go
+++ b/runner/userns_linux_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package runner
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyUserNamespace_Nil(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	applyUserNamespace(cmd, nil)
+
+	// SysProcAttr should be unchanged.
+	assert.Equal(t, syscall.CLONE_NEWUSER&cmd.SysProcAttr.Cloneflags, uintptr(0))
+	assert.Nil(t, cmd.SysProcAttr.UidMappings)
+	assert.Nil(t, cmd.SysProcAttr.GidMappings)
+}
+
+func TestApplyUserNamespace_SetsCloneflags(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	ns := &UserNamespaceConfig{UID: 1000, GID: 1000}
+	applyUserNamespace(cmd, ns)
+
+	assert.NotEqual(t, uintptr(0), cmd.SysProcAttr.Cloneflags&syscall.CLONE_NEWUSER,
+		"CLONE_NEWUSER should be set")
+	// Setsid should still be set.
+	assert.True(t, cmd.SysProcAttr.Setsid)
+}
+
+func TestApplyUserNamespace_UIDMapping(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	ns := &UserNamespaceConfig{UID: 1000, GID: 1000}
+	applyUserNamespace(cmd, ns)
+
+	require.Len(t, cmd.SysProcAttr.UidMappings, 1)
+	assert.Equal(t, 1000, cmd.SysProcAttr.UidMappings[0].ContainerID)
+	assert.Equal(t, int(syscall.Getuid()), cmd.SysProcAttr.UidMappings[0].HostID)
+	assert.Equal(t, 1, cmd.SysProcAttr.UidMappings[0].Size)
+}
+
+func TestApplyUserNamespace_GIDMapping(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	ns := &UserNamespaceConfig{UID: 1000, GID: 1000}
+	applyUserNamespace(cmd, ns)
+
+	require.Len(t, cmd.SysProcAttr.GidMappings, 1)
+	assert.Equal(t, 1000, cmd.SysProcAttr.GidMappings[0].ContainerID)
+	assert.Equal(t, int(syscall.Getgid()), cmd.SysProcAttr.GidMappings[0].HostID)
+	assert.Equal(t, 1, cmd.SysProcAttr.GidMappings[0].Size)
+}
+
+func TestApplyUserNamespace_SetgroupsDenied(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	ns := &UserNamespaceConfig{UID: 1000, GID: 1000}
+	applyUserNamespace(cmd, ns)
+
+	// GidMappingsEnableSetgroups should be false (zero value), which causes
+	// Go to write "deny" to /proc/<pid>/setgroups before writing gid_map.
+	assert.False(t, cmd.SysProcAttr.GidMappingsEnableSetgroups)
+}
+
+func TestApplyUserNamespace_PreservesExistingCloneflags(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid:     true,
+		Cloneflags: syscall.CLONE_NEWNS, // Pre-existing flag
+	}
+
+	ns := &UserNamespaceConfig{UID: 500, GID: 500}
+	applyUserNamespace(cmd, ns)
+
+	// Both CLONE_NEWNS and CLONE_NEWUSER should be set.
+	assert.NotEqual(t, uintptr(0), cmd.SysProcAttr.Cloneflags&syscall.CLONE_NEWUSER)
+	assert.NotEqual(t, uintptr(0), cmd.SysProcAttr.Cloneflags&syscall.CLONE_NEWNS)
+}

--- a/runner/userns_other.go
+++ b/runner/userns_other.go
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package runner
+
+import "os/exec"
+
+// applyUserNamespace is a no-op on non-Linux platforms. User namespaces
+// are a Linux-specific feature.
+func applyUserNamespace(_ *exec.Cmd, _ *UserNamespaceConfig) {}


### PR DESCRIPTION
## Summary

- Spawn the propolis-runner inside a `CLONE_NEWUSER` namespace so it gains `CAP_SETUID`/`CAP_SETGID` within the namespace
- Fixes virtiofs `set_creds()` EPERM errors when host GID != guest GID (e.g., on openSUSE MicroOS where host uid=1000/gid=1001 but guest expects uid=1000/gid=1000)
- Add `WithUserNamespaceUID(uid, gid)` backend option for callers (brood-box, waggle) to opt in
- Add preflight check for `kernel.unprivileged_userns_clone` sysctl with clear remediation message

## Details

**Problem**: libkrun's virtiofs passthrough calls `set_creds(ctx.uid, ctx.gid)` before every file operation. When the runner process lacks `CAP_SETGID` and the host GID doesn't match the guest GID, `set_creds` returns EPERM — breaking all file creation on virtiofs mounts.

**Solution**: Spawn the runner in a `CLONE_NEWUSER` namespace with a single UID/GID mapping. The child process gains all capabilities within the namespace, so `has_cap(CAP_SETGID)` returns true and `set_creds` succeeds.

**New files**:
- `runner/userns.go` — cross-platform `UserNamespaceConfig` type
- `runner/userns_linux.go` — `applyUserNamespace()` sets `CLONE_NEWUSER`, writes uid/gid mappings, denies setgroups
- `runner/userns_other.go` — no-op on non-Linux
- `preflight/userns_linux.go` — checks `kernel.unprivileged_userns_clone` sysctl
- `preflight/userns_other.go` — no-op on non-Linux

**Modified files**:
- `runner/config.go` — `UserNamespace *UserNamespaceConfig` field (`json:"-"`)
- `runner/spawn.go` — calls `applyUserNamespace` after SysProcAttr init; adds EPERM hint suggesting sysctl check
- `hypervisor/libkrun/backend.go` — `WithUserNamespaceUID(uid, gid)` option, threaded through `Start()`

## Test plan

- [x] `task fmt && task lint` — 0 issues
- [x] `task test-nocgo` — all passing
- [x] Manual test on openSUSE MicroOS (host gid=1001, guest gid=1000) — virtiofs file creation works with user namespace enabled
- [ ] Verify on system with `kernel.unprivileged_userns_clone=0` — should produce clear preflight error

🤖 Generated with [Claude Code](https://claude.com/claude-code)