### PR TITLE
Fix SSH agent forwarding handled in wrong request handler

### DIFF
--- a/guest/sshd/server.go
+++ b/guest/sshd/server.go
@@ -274,32 +274,12 @@ func (s *Server) handleConnection(netConn net.Conn) {
 }
 
 // handleGlobalRequests processes connection-level SSH requests.
-// It handles agent forwarding requests when enabled and discards
-// all other global requests.
-func (s *Server) handleGlobalRequests(reqs <-chan *ssh.Request, conn *ssh.ServerConn) {
+// It rejects all global requests; session-specific requests like
+// agent forwarding are handled in handleSession.
+func (s *Server) handleGlobalRequests(reqs <-chan *ssh.Request, _ *ssh.ServerConn) {
 	for req := range reqs {
-		switch req.Type {
-		case "auth-agent-req@openssh.com":
-			if s.cfg.AgentForwarding {
-				s.setAgentForwarding(conn, true)
-				s.logger.Info("agent forwarding enabled",
-					"remote", conn.RemoteAddr(),
-				)
-				if req.WantReply {
-					_ = req.Reply(true, nil)
-				}
-			} else {
-				s.logger.Debug("agent forwarding rejected (disabled)",
-					"remote", conn.RemoteAddr(),
-				)
-				if req.WantReply {
-					_ = req.Reply(false, nil)
-				}
-			}
-		default:
-			if req.WantReply {
-				_ = req.Reply(false, nil)
-			}
+		if req.WantReply {
+			_ = req.Reply(false, nil)
 		}
 	}
 }

--- a/guest/sshd/server_test.go
+++ b/guest/sshd/server_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 // generateTestKeyPair creates an ECDSA P-256 key pair for testing and
@@ -327,10 +328,13 @@ func TestAgentForwardingDisabled(t *testing.T) {
 
 	client := dialSSH(t, addr, signer)
 
-	// Request agent forwarding — should be rejected.
-	ok, _, err := client.SendRequest("auth-agent-req@openssh.com", true, nil)
+	session, err := client.NewSession()
 	require.NoError(t, err)
-	assert.False(t, ok, "agent forwarding should be rejected when disabled")
+	defer func() { _ = session.Close() }()
+
+	// Request agent forwarding via the real API — should be rejected.
+	err = agent.RequestAgentForwarding(session)
+	assert.Error(t, err, "agent forwarding should be rejected when disabled")
 }
 
 func TestAgentForwardingEnabled(t *testing.T) {
@@ -352,10 +356,23 @@ func TestAgentForwardingEnabled(t *testing.T) {
 
 	client := dialSSH(t, addr, signer)
 
-	// Request agent forwarding — should be accepted.
-	ok, _, err := client.SendRequest("auth-agent-req@openssh.com", true, nil)
+	session, err := client.NewSession()
 	require.NoError(t, err)
-	assert.True(t, ok, "agent forwarding should be accepted when enabled")
+	defer func() { _ = session.Close() }()
+
+	// Request agent forwarding via the real API — should be accepted.
+	err = agent.RequestAgentForwarding(session)
+	require.NoError(t, err, "agent forwarding should be accepted when enabled")
+
+	// Verify the flag was set by running a command on a second session.
+	session2, err := client.NewSession()
+	require.NoError(t, err)
+	defer func() { _ = session2.Close() }()
+
+	output, err := session2.CombinedOutput("echo ${SSH_AUTH_SOCK:-unset}")
+	require.NoError(t, err)
+	result := strings.TrimSpace(string(output))
+	assert.Contains(t, result, "/tmp/ssh-", "agent socket should be set on connection after forwarding request")
 }
 
 func TestAgentSocketCreated(t *testing.T) {
@@ -377,15 +394,14 @@ func TestAgentSocketCreated(t *testing.T) {
 
 	client := dialSSH(t, addr, signer)
 
-	// Request agent forwarding.
-	ok, _, err := client.SendRequest("auth-agent-req@openssh.com", true, nil)
-	require.NoError(t, err)
-	require.True(t, ok)
-
-	// Run a command that checks if SSH_AUTH_SOCK is set.
+	// Request agent forwarding and run a command on the same session,
+	// which is the real client flow: auth-agent-req arrives before exec.
 	session, err := client.NewSession()
 	require.NoError(t, err)
 	defer func() { _ = session.Close() }()
+
+	err = agent.RequestAgentForwarding(session)
+	require.NoError(t, err)
 
 	output, err := session.CombinedOutput("echo $SSH_AUTH_SOCK")
 	require.NoError(t, err)

--- a/guest/sshd/session.go
+++ b/guest/sshd/session.go
@@ -119,6 +119,20 @@ func (s *Server) handleSession(ch ssh.Channel, requests <-chan *ssh.Request, con
 				replyRequest(req, false)
 			}
 
+		case "auth-agent-req@openssh.com":
+			if s.cfg.AgentForwarding {
+				s.setAgentForwarding(conn, true)
+				s.logger.Info("agent forwarding enabled",
+					"remote", conn.RemoteAddr(),
+				)
+				replyRequest(req, true)
+			} else {
+				s.logger.Debug("agent forwarding rejected (disabled)",
+					"remote", conn.RemoteAddr(),
+				)
+				replyRequest(req, false)
+			}
+
 		case "exec":
 			var payload struct {
 				Command string


### PR DESCRIPTION
## Summary

- **Move `auth-agent-req@openssh.com` handling** from `handleGlobalRequests` (`SSH_MSG_GLOBAL_REQUEST`) to `handleSession` (`SSH_MSG_CHANNEL_REQUEST`), matching the SSH spec and what real clients actually send
- **Remove dead code** from `handleGlobalRequests` — no standard SSH client sends agent forwarding as a global request, so the old handler was never reached in practice
- **Fix tests** to use `agent.RequestAgentForwarding(session)` instead of `client.SendRequest(...)`, exercising the correct code path including a same-session end-to-end test verifying `SSH_AUTH_SOCK` is set

## Context

Per the SSH spec and Go's `agent.RequestAgentForwarding(session)`, the `auth-agent-req@openssh.com` request is sent as a **session channel request** (`SSH_MSG_CHANNEL_REQUEST`). It was incorrectly handled in `handleGlobalRequests` which processes `SSH_MSG_GLOBAL_REQUEST` packets. The request would arrive in `handleSession`, hit the `default` case, and get rejected — agent forwarding never worked for real clients.

The existing tests passed because they used `client.SendRequest()` (global request) instead of `session.SendRequest()` (channel request), exercising the wrong code path.

## Test plan

- [x] `go test -v -race ./guest/sshd/` — all 12 tests pass
- [x] `CGO_ENABLED=0 go vet` on non-CGO packages — clean
- [x] `go fmt` / `go vet` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)