### PR TITLE
Allow empty AllowedHosts in EgressPolicy for deny-all

### DIFF
--- a/microvm.go
+++ b/microvm.go
@@ -77,9 +77,6 @@ func Run(ctx context.Context, imageRef string, opts ...Option) (*VM, error) {
 
 	// Egress policy validation.
 	if cfg.egressPolicy != nil {
-		if len(cfg.egressPolicy.AllowedHosts) == 0 {
-			return nil, fmt.Errorf("egress policy: AllowedHosts must not be empty")
-		}
 		for i, h := range cfg.egressPolicy.AllowedHosts {
 			if h.Name == "" {
 				return nil, fmt.Errorf("egress policy: AllowedHosts[%d].Name must not be empty", i)

--- a/microvm_test.go
+++ b/microvm_test.go
@@ -627,6 +627,24 @@ func TestBuildNetConfig_WithEgressPolicy(t *testing.T) {
 	assert.Equal(t, uint8(0), netCfg.EgressPolicy.AllowedHosts[1].Protocol)
 }
 
+func TestBuildNetConfig_WithEgressPolicy_DenyAll(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultConfig()
+	cfg.egressPolicy = &EgressPolicy{
+		AllowedHosts: []EgressHost{},
+	}
+	// Run() sets this when egressPolicy is non-nil; simulate that here
+	// since buildNetConfig doesn't do validation.
+	cfg.firewallDefaultAction = firewall.Deny
+
+	netCfg := cfg.buildNetConfig()
+
+	require.NotNil(t, netCfg.EgressPolicy)
+	assert.Empty(t, netCfg.EgressPolicy.AllowedHosts)
+	assert.Equal(t, firewall.Deny, netCfg.FirewallDefaultAction)
+}
+
 func TestBuildNetConfig_Empty(t *testing.T) {
 	t.Parallel()
 
@@ -642,7 +660,7 @@ func TestBuildNetConfig_Empty(t *testing.T) {
 
 // --- Egress validation tests ---
 
-func TestRun_EgressPolicy_EmptyHosts(t *testing.T) {
+func TestRun_EgressPolicy_EmptyHosts_DenyAll(t *testing.T) {
 	t.Parallel()
 
 	dataDir := t.TempDir()
@@ -651,8 +669,10 @@ func TestRun_EgressPolicy_EmptyHosts(t *testing.T) {
 		WithDataDir(dataDir),
 		WithEgressPolicy(EgressPolicy{AllowedHosts: nil}),
 	)
+	// Should NOT fail on empty AllowedHosts validation — empty means deny-all.
+	// It will fail later (e.g. image pull), but not at egress policy validation.
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "AllowedHosts must not be empty")
+	assert.NotContains(t, err.Error(), "AllowedHosts must not be empty")
 }
 
 func TestRun_EgressPolicy_EmptyName(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove validation that rejected `EgressPolicy` with empty `AllowedHosts` slice
- Empty `AllowedHosts` now means "deny all egress" — firewall default is `Deny` with no hosts whitelisted
- Add `TestBuildNetConfig_WithEgressPolicy_DenyAll` to verify the deny-all config path

Fixes #54

## Test plan

- [x] `TestRun_EgressPolicy_EmptyHosts_DenyAll` — empty hosts no longer rejected at validation
- [x] `TestBuildNetConfig_WithEgressPolicy_DenyAll` — empty hosts produces valid config with `firewall.Deny`
- [x] Existing egress tests still pass (wildcard validation, empty name rejection, valid policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)