### PR TITLE
Soften io_uring seccomp action from KillProcess to Errno

### DIFF
--- a/guest/harden/seccomp.go
+++ b/guest/harden/seccomp.go
@@ -56,11 +56,6 @@ func exploitIndicatorBlocks() secbpf.SyscallGroup {
 	return secbpf.SyscallGroup{
 		Action: secbpf.ActionKillProcess,
 		Names: []string{
-			// io_uring — prolific source of kernel CVEs.
-			"io_uring_setup",
-			"io_uring_enter",
-			"io_uring_register",
-
 			// Process debugging / cross-process memory access.
 			"ptrace",
 			"process_vm_readv",
@@ -91,6 +86,15 @@ func operationalBlocks() secbpf.SyscallGroup {
 	return secbpf.SyscallGroup{
 		Action: secbpf.ActionErrno,
 		Names: []string{
+			// io_uring — prolific source of kernel CVEs. Returns EPERM
+			// (rather than killing) because libuv 1.52+ probes io_uring_setup
+			// unconditionally on Linux and falls back to epoll when the
+			// syscall fails. UV_USE_IO_URING=0 does not gate the probe in
+			// libuv 1.52 (only the SQPOLL path honors it).
+			"io_uring_setup",
+			"io_uring_enter",
+			"io_uring_register",
+
 			// Filesystem manipulation — boot is already done.
 			"mount",
 			"umount2",

--- a/guest/harden/seccomp_test.go
+++ b/guest/harden/seccomp_test.go
@@ -24,9 +24,6 @@ func TestExploitIndicatorBlocks(t *testing.T) {
 	assert.Equal(t, secbpf.ActionKillProcess, group.Action)
 
 	expected := []string{
-		"io_uring_setup",
-		"io_uring_enter",
-		"io_uring_register",
 		"ptrace",
 		"process_vm_readv",
 		"process_vm_writev",
@@ -48,6 +45,9 @@ func TestOperationalBlocks(t *testing.T) {
 	assert.Equal(t, secbpf.ActionErrno, group.Action)
 
 	expected := []string{
+		"io_uring_setup",
+		"io_uring_enter",
+		"io_uring_register",
 		"mount",
 		"umount2",
 		"pivot_root",


### PR DESCRIPTION
## Summary

Move `io_uring_setup`, `io_uring_enter`, and `io_uring_register` from `exploitIndicatorBlocks` (`SECCOMP_RET_KILL_PROCESS`) to `operationalBlocks` (`SECCOMP_RET_ERRNO`). The syscalls remain blocked — they now return `-EPERM` instead of killing the process.

## Why

libuv 1.52+ calls `io_uring_setup()` unconditionally during event-loop init. `uv__use_io_uring()` short-circuits to `return 1` for the non-SQPOLL path *before* consulting `UV_USE_IO_URING`, so the env-var workaround is a no-op:

```c
if (0 == (flags & UV__IORING_SETUP_SQPOLL))
  return 1;
```

Result: any libuv-based runtime — including Node 25, which ships in the brood-box Gemini CLI image — gets killed with SIGSYS at startup, well before user code runs. Gemini CLI dies in 200ms with no diagnostic output. This is a benign runtime probe, not exploitation.

## Why this is not a security regression

- The seccomp filter rejects the syscall in the same kernel path for both actions; no `io_uring`-specific kernel work happens before the rejection. There is no CVE class that `KillProcess` mitigates here that `Errno` doesn't.
- libuv handles `io_uring_setup` returning `-1` cleanly and falls back to epoll (`if (ringfd == -1) return;`).
- This matches Docker's and containerd's default seccomp profiles, which also classify `io_uring_*` as `Errno` ([moby#46762](https://github.com/moby/moby/pull/46762)).
- Process-debugging syscalls (`ptrace`, `process_vm_readv/writev`, `bpf`, `seccomp`, `kexec_*`, `*_module`) remain at `KillProcess` — none of those have legitimate runtime callers.

A deeper security review surfaced several follow-up hardening wins worth tracking separately:
- `clone3 → ENOSYS` (biggest gap — current `cloneNamespaceBlock` is partially bypassable because BPF can't inspect `clone3`'s struct args; the standard fix is `ENOSYS` so glibc 2.34+ falls back to `clone()`)
- `kernel.io_uring_disabled=2` sysctl (Linux 6.6+ system-wide kill switch)
- `user.max_user_namespaces=0` sysctl
- `pidfd_getfd` / `pidfd_open` block (same access class as `process_vm_readv`)
- `memfd_secret` block

These are out of scope for this PR.

## Test plan

- [x] `go test ./guest/harden/...` passes
- [x] `go test ./...` passes
- [x] End-to-end: rebuilt brood-box against this branch (via local `replace`), ran `bbox gemini` — interactive Gemini UI starts (was crashing in 200ms before)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)