### PR TITLE
Bump libkrun to v1.18.0 and libkrunfw to v5.4.0

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -48,7 +48,7 @@ toolchain that CI and Release need.
    arm64 on `ubuntu-24.04-arm`) — no QEMU emulation
 2. Pushes each image by digest
 3. Merges digests into a multi-arch manifest tagged with the libkrun
-   version (e.g., `v1.17.3`) and `latest`
+   version (e.g., `v1.18.0`) and `latest`
 
 The build takes ~20 minutes because it compiles a Linux kernel (libkrunfw).
 Results are cached via GitHub Actions cache.

--- a/images/builder/Containerfile
+++ b/images/builder/Containerfile
@@ -3,8 +3,8 @@
 
 # Builder container image for building libkrun + libkrunfw from source.
 
-ARG LIBKRUN_VERSION=v1.17.3
-ARG LIBKRUNFW_VERSION=v5.2.0
+ARG LIBKRUN_VERSION=v1.18.0
+ARG LIBKRUNFW_VERSION=v5.4.0
 
 FROM fedora:43
 

--- a/versions.env
+++ b/versions.env
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 # SPDX-License-Identifier: Apache-2.0
-LIBKRUN_VERSION=v1.17.3
-LIBKRUNFW_VERSION=v5.2.0
+LIBKRUN_VERSION=v1.18.0
+LIBKRUNFW_VERSION=v5.4.0


### PR DESCRIPTION
## Summary

- Bumps `LIBKRUN_VERSION` from `v1.17.3` to `v1.18.0`
- Bumps `LIBKRUNFW_VERSION` from `v5.2.0` to `v5.4.0`
- Updates Containerfile defaults and `docs/CI.md` example to match

## Why

We're a few releases behind on both libraries. The most notable changes:

**libkrun v1.17.3 → v1.18.0**
- Nested virt support on Linux (KVM intel/amd nested params probed)
- New virtio drivers: snd, input, rng, can, rtc
- Read-only virtiofs mounts (#623)
- KILLPRIV → KILLPRIV_V2, cap-ng → caps refactor
- Many vsock/tsi, virtio-fs/macOS, and init fixes

**libkrunfw v5.2.0 → v5.4.0**
- Rebased on Linux kernel 6.12.87
- KVM enabled in embedded kernel (pairs with libkrun nested virt)
- virtio-snd, virtio-can, virtio-input, virtio-rtc drivers enabled
- EROFS xattr/security support on x86_64

Full release notes:
- https://github.com/containers/libkrun/releases/tag/v1.18.0
- https://github.com/containers/libkrunfw/releases/tag/v5.4.0

## Test plan

Already validated locally on linux/amd64:

- [x] `task builder-image-build` — clean build of libkrun v1.18.0 + libkrunfw v5.4.0 from source
- [x] `task build-runner` — Go bindings compile against the new libkrun (no CGO breakage)
- [x] `task test-nocgo` — all pure-Go tests pass
- [x] CGO tests for `./krun/...` and `./hypervisor/libkrun/...` pass inside the new builder image
- [x] End-to-end: bbox claude-code boots a microVM in ~2.66s, executes a command inside, shuts down cleanly

Once merged:
- [ ] CI Linux CGO job will fail until the Builder workflow rebuilds the image (~20 min)
- [ ] Re-run the failed CI job, then tag a release to produce updated runtime/firmware artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)