### PR TITLE
Gate guest/boot SSH bring-up behind a nosshd build tag (opt-out)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -166,17 +166,19 @@ tasks:
   # =============================================================================
 
   test:
-    desc: Run unit tests
+    desc: Run unit tests (both default and -tags=nosshd variants of guest/boot)
     cmds:
       - go test -v -race ./...
+      - go test -v -race -tags=nosshd ./...
 
   test-nocgo:
-    desc: Run unit tests excluding CGO packages
+    desc: Run unit tests excluding CGO packages (both default and -tags=nosshd variants)
     cmds:
       - go test -v -race $(go list ./... | grep -v krun | grep -v go-microvm-runner)
+      - go test -v -race -tags=nosshd $(go list ./... | grep -v krun | grep -v go-microvm-runner)
 
   test-coverage:
-    desc: Run tests with coverage
+    desc: Run tests with coverage (default build covers the SSH path)
     cmds:
       - go test -v -race -coverprofile=coverage.out ./...
       - go tool cover -html=coverage.out -o coverage.html
@@ -204,11 +206,12 @@ tasks:
       - go mod tidy
 
   build-nocgo:
-    desc: Verify compilation of pure Go packages (no CGO)
+    desc: Verify compilation of pure Go packages (no CGO), both default and -tags=nosshd
     env:
       CGO_ENABLED: "0"
     cmds:
       - go build $(go list ./... | grep -v krun | grep -v go-microvm-runner)
+      - go build -tags=nosshd $(go list ./... | grep -v krun | grep -v go-microvm-runner)
 
   verify:
     desc: Verify code (fmt, lint, test)

--- a/guest/boot/boot.go
+++ b/guest/boot/boot.go
@@ -6,24 +6,18 @@
 package boot
 
 import (
-	"bufio"
 	"fmt"
 	"log/slog"
-	"net"
 	"os"
-
-	"golang.org/x/crypto/ssh"
 
 	"github.com/stacklok/go-microvm/guest/env"
 	"github.com/stacklok/go-microvm/guest/harden"
 	"github.com/stacklok/go-microvm/guest/mount"
 	"github.com/stacklok/go-microvm/guest/netcfg"
-	"github.com/stacklok/go-microvm/guest/sshd"
 )
 
-// Run executes the full guest boot sequence and returns a shutdown function
-// that stops the SSH server. The caller should block on signals and then
-// invoke shutdown before halting.
+// Run executes the full guest boot sequence and returns a shutdown function.
+// The caller should block on signals and then invoke shutdown before halting.
 //
 // Boot sequence:
 //  1. Essential mounts (/proc, /sys, /dev, etc.)
@@ -33,12 +27,17 @@ import (
 //  5. Lock down /root (if enabled)
 //  6. Fix home directory ownership (rootfs hooks may not chown on macOS)
 //  7. Load environment file
-//  8. Parse SSH authorized keys (skipped when [WithoutSSH] is set)
-//  9. Drop bounding capabilities + set no_new_privs
-//  10. Start SSH server (skipped when [WithoutSSH] is set)
-//  11. Apply seccomp BPF filter (if enabled via [WithSeccomp])
+//  8. Drop bounding capabilities + set no_new_privs
+//  9. SSH bring-up (skipped when [WithoutSSH] is set or when built with -tags=nosshd)
+//  10. Apply seccomp BPF filter (if enabled via [WithSeccomp])
 //
-// When SSH is disabled, the returned shutdown function is a no-op.
+// The SSH bring-up (parsing authorized_keys, loading the host key, starting
+// the listener) lives in build-tag-gated files. By default the SSH path is
+// compiled in — passing -tags=nosshd at build time strips it, removing
+// golang.org/x/crypto/ssh from the dependency graph. Builds with that tag
+// must call [WithoutSSH] to acknowledge that SSH is unavailable.
+//
+// When SSH is not brought up, the returned shutdown function is a no-op.
 func Run(logger *slog.Logger, opts ...Option) (shutdown func(), err error) {
 	cfg := defaultConfig()
 	for _, o := range opts {
@@ -91,33 +90,7 @@ func Run(logger *slog.Logger, opts ...Option) (shutdown func(), err error) {
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	// 8. Parse authorized keys (skipped when SSH is disabled).
-	var authorizedKeys []ssh.PublicKey
-	var hostKeySigner ssh.Signer
-	if !cfg.disableSSH {
-		authorizedKeys, err = ParseAuthorizedKeys(cfg.sshKeysPath)
-		if err != nil {
-			return nil, fmt.Errorf("parsing authorized keys: %w", err)
-		}
-
-		// 8b. Load injected host key (if present). The key is deleted from
-		// disk after loading into memory so it cannot be read by the sandbox
-		// user. If the file does not exist, hostKeySigner remains nil and the
-		// SSH server will generate an ephemeral key.
-		if hostKeyPEM, readErr := os.ReadFile(cfg.sshHostKeyPath); readErr == nil {
-			signer, parseErr := ssh.ParsePrivateKey(hostKeyPEM)
-			if parseErr != nil {
-				logger.Warn("failed to parse injected host key, falling back to ephemeral",
-					"path", cfg.sshHostKeyPath, "error", parseErr)
-			} else {
-				hostKeySigner = signer
-				logger.Info("loaded injected SSH host key", "path", cfg.sshHostKeyPath)
-			}
-			_ = os.Remove(cfg.sshHostKeyPath)
-		}
-	}
-
-	// 9. Drop unneeded capabilities from the bounding set.
+	// 8. Drop unneeded capabilities from the bounding set.
 	logger.Info("dropping unnecessary capabilities")
 	if err := harden.DropBoundingCaps(
 		harden.CapSetUID,
@@ -132,45 +105,15 @@ func Run(logger *slog.Logger, opts ...Option) (shutdown func(), err error) {
 		return nil, fmt.Errorf("setting no_new_privs: %w", err)
 	}
 
-	// 10. Start SSH server (skipped when SSH is disabled — bbox-k8s uses
-	// ttrpc-over-vsock instead).
-	shutdown = func() {}
-	if !cfg.disableSSH {
-		sshdCfg := sshd.Config{
-			Port:            cfg.sshPort,
-			AuthorizedKeys:  authorizedKeys,
-			Env:             envVars,
-			DefaultUID:      cfg.userUID,
-			DefaultGID:      cfg.userGID,
-			DefaultUser:     cfg.userName,
-			DefaultHome:     cfg.userHome,
-			DefaultShell:    cfg.userShell,
-			DefaultWorkDir:  cfg.workspaceMountPoint,
-			AgentForwarding: cfg.sshAgentForwarding,
-			HostKey:         hostKeySigner,
-			Logger:          logger,
-		}
-		srv, err := sshd.New(sshdCfg)
-		if err != nil {
-			return nil, fmt.Errorf("creating SSH server: %w", err)
-		}
-
-		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.sshPort))
-		if err != nil {
-			return nil, fmt.Errorf("listening on port %d: %w", cfg.sshPort, err)
-		}
-
-		go func() {
-			if err := srv.Serve(ln); err != nil {
-				logger.Error("SSH server error", "error", err)
-			}
-		}()
-		shutdown = func() { srv.Close() }
-	} else {
-		logger.Info("SSH bring-up disabled via WithoutSSH")
+	// 9. SSH bring-up. The real implementation lives in ssh_enabled.go
+	// (//go:build sshd); the stub in ssh_disabled.go errors out if the
+	// caller wanted SSH but the binary wasn't built with the tag.
+	shutdown, err = bringUpSSH(logger, cfg, envVars)
+	if err != nil {
+		return nil, fmt.Errorf("ssh bring-up: %w", err)
 	}
 
-	// 11. Apply seccomp BPF filter (if enabled). This must be the last
+	// 10. Apply seccomp BPF filter (if enabled). This must be the last
 	// step — all mounts, networking, and privileged operations are done.
 	if cfg.seccomp {
 		logger.Info("applying seccomp BPF filter")
@@ -179,11 +122,7 @@ func Run(logger *slog.Logger, opts ...Option) (shutdown func(), err error) {
 		}
 	}
 
-	if cfg.disableSSH {
-		logger.Info("sandbox init ready (SSH disabled)")
-	} else {
-		logger.Info("sandbox init ready", "ssh_port", cfg.sshPort)
-	}
+	logger.Info("sandbox init ready")
 
 	return shutdown, nil
 }
@@ -195,35 +134,4 @@ func lockdownRoot(logger *slog.Logger) {
 	if err := os.Chmod("/root", 0o700); err != nil {
 		logger.Warn("failed to chmod /root", "error", err)
 	}
-}
-
-// ParseAuthorizedKeys reads an authorized_keys file and returns the parsed
-// public keys. Returns an error if no valid keys are found.
-func ParseAuthorizedKeys(path string) ([]ssh.PublicKey, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("opening %s: %w", path, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	var keys []ssh.PublicKey
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 || line[0] == '#' {
-			continue
-		}
-		key, _, _, _, err := ssh.ParseAuthorizedKey(line)
-		if err != nil {
-			continue // skip unparseable lines
-		}
-		keys = append(keys, key)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("reading %s: %w", path, err)
-	}
-	if len(keys) == 0 {
-		return nil, fmt.Errorf("no valid keys found in %s", path)
-	}
-	return keys, nil
 }

--- a/guest/boot/boot_test.go
+++ b/guest/boot/boot_test.go
@@ -6,16 +6,9 @@
 package boot
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -144,79 +137,4 @@ func TestOptionComposition(t *testing.T) {
 	// Unchanged defaults.
 	assert.Equal(t, "/workspace", cfg.workspaceMountPoint)
 	assert.Equal(t, "/etc/sandbox-env", cfg.envFilePath)
-}
-
-func TestParseAuthorizedKeys(t *testing.T) {
-	t.Parallel()
-
-	t.Run("valid key", func(t *testing.T) {
-		t.Parallel()
-		key, pubKeyStr := generateTestKey(t)
-		_ = key
-
-		dir := t.TempDir()
-		path := filepath.Join(dir, "authorized_keys")
-		require.NoError(t, os.WriteFile(path, []byte(pubKeyStr+"\n"), 0o600))
-
-		keys, err := ParseAuthorizedKeys(path)
-		require.NoError(t, err)
-		assert.Len(t, keys, 1)
-	})
-
-	t.Run("missing file", func(t *testing.T) {
-		t.Parallel()
-		_, err := ParseAuthorizedKeys("/nonexistent/authorized_keys")
-		assert.Error(t, err)
-	})
-
-	t.Run("empty file", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "authorized_keys")
-		require.NoError(t, os.WriteFile(path, []byte(""), 0o600))
-
-		_, err := ParseAuthorizedKeys(path)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "no valid keys")
-	})
-
-	t.Run("invalid key skipped", func(t *testing.T) {
-		t.Parallel()
-		_, pubKeyStr := generateTestKey(t)
-
-		dir := t.TempDir()
-		path := filepath.Join(dir, "authorized_keys")
-		content := "not-a-valid-key\n" + pubKeyStr + "\n"
-		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
-
-		keys, err := ParseAuthorizedKeys(path)
-		require.NoError(t, err)
-		assert.Len(t, keys, 1)
-	})
-
-	t.Run("comments skipped", func(t *testing.T) {
-		t.Parallel()
-		_, pubKeyStr := generateTestKey(t)
-
-		dir := t.TempDir()
-		path := filepath.Join(dir, "authorized_keys")
-		content := "# comment\n" + pubKeyStr + "\n"
-		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
-
-		keys, err := ParseAuthorizedKeys(path)
-		require.NoError(t, err)
-		assert.Len(t, keys, 1)
-	})
-}
-
-// generateTestKey creates an ECDSA key pair and returns the signer and
-// the authorized_keys-formatted public key string.
-func generateTestKey(t *testing.T) (ssh.Signer, string) {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	signer, err := ssh.NewSignerFromKey(key)
-	require.NoError(t, err)
-	pubKeyStr := string(ssh.MarshalAuthorizedKey(signer.PublicKey()))
-	return signer, pubKeyStr
 }

--- a/guest/boot/doc.go
+++ b/guest/boot/doc.go
@@ -4,8 +4,23 @@
 //go:build linux
 
 // Package boot orchestrates the guest VM boot sequence: essential mounts,
-// networking, workspace mount, kernel hardening, environment loading, SSH
-// key parsing, capability dropping, and SSH server start. It uses functional
-// options to replace the hardcoded values found in consumer-specific init
-// processes, making it reusable across different guest VM configurations.
+// networking, workspace mount, kernel hardening, environment loading,
+// capability dropping, optional SSH server start, and optional seccomp
+// filtering. It uses functional options to replace the hardcoded values
+// found in consumer-specific init processes, making it reusable across
+// different guest VM configurations.
+//
+// # SSH support is build-tag gated
+//
+// The SSH bring-up (authorized_keys parsing, host-key loading, listener
+// start) is compiled in by default. Consumers that do not want the SSH
+// path linked into their guest init binary can pass -tags=nosshd at
+// build time: this swaps in a stub that does not import
+// golang.org/x/crypto/ssh, and [Run] then refuses to start unless the
+// caller has signalled SSH-off via [WithoutSSH].
+//
+// Consumers that need SSH (e.g. brood-box) need no build-time change.
+// Consumers that don't (e.g. bbox-k8s, which uses ttrpc-over-vsock)
+// build their init binary with -tags=nosshd and call [WithoutSSH] from
+// it; the resulting binary has no SSH dependency in its link-time graph.
 package boot

--- a/guest/boot/ssh_disabled.go
+++ b/guest/boot/ssh_disabled.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && nosshd
+
+package boot
+
+import (
+	"errors"
+	"log/slog"
+)
+
+// ErrSSHNotBuilt is returned by [Run] when the binary was compiled with
+// -tags=nosshd and the caller did not opt out of SSH bring-up via
+// [WithoutSSH]. Catching it explicitly is useful for consumers that want
+// to detect the "SSH stripped at build time but no acknowledgement"
+// misconfiguration as a distinct case from a runtime SSH failure.
+var ErrSSHNotBuilt = errors.New(
+	"guest/boot: SSH support stripped at build time (-tags=nosshd); call WithoutSSH() to acknowledge",
+)
+
+// bringUpSSH is the no-SSH stub. Compiled into binaries built with the
+// nosshd build tag — see ssh_enabled.go for the default implementation.
+//
+// When the caller acknowledged the SSH-off path via [WithoutSSH], this is
+// a no-op that returns a no-op shutdown. When the caller did NOT call
+// [WithoutSSH], it returns [ErrSSHNotBuilt] to fail loud rather than
+// silently boot without SSH.
+func bringUpSSH(logger *slog.Logger, cfg *config, _ []string) (func(), error) {
+	if !cfg.disableSSH {
+		return nil, ErrSSHNotBuilt
+	}
+	logger.Info("SSH bring-up skipped (built with -tags=nosshd)")
+	return func() {}, nil
+}

--- a/guest/boot/ssh_disabled_test.go
+++ b/guest/boot/ssh_disabled_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && nosshd
+
+package boot
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBringUpSSH_DisabledStub_NoOpWhenAcknowledged(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	cfg.disableSSH = true
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	shutdown, err := bringUpSSH(logger, cfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+	shutdown() // must not panic
+}
+
+func TestBringUpSSH_DisabledStub_ErrorsWhenNotAcknowledged(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	// disableSSH left false — caller did NOT call WithoutSSH().
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	shutdown, err := bringUpSSH(logger, cfg, nil)
+	require.Error(t, err)
+	assert.Nil(t, shutdown)
+	assert.True(t, errors.Is(err, ErrSSHNotBuilt),
+		"expected ErrSSHNotBuilt, got %v", err)
+}

--- a/guest/boot/ssh_enabled.go
+++ b/guest/boot/ssh_enabled.go
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && !nosshd
+
+package boot
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/stacklok/go-microvm/guest/sshd"
+)
+
+// bringUpSSH performs the SSH-specific portion of the boot sequence:
+// parses authorized_keys, loads an injected host key if present, and
+// starts the embedded SSH server listener. Returns a shutdown closure
+// that stops the server.
+//
+// When [WithoutSSH] has set cfg.disableSSH, this function is a no-op
+// returning a no-op shutdown — the caller can still build with -tags=sshd
+// and run with SSH off at runtime.
+//
+// Compiled into the binary by default. Pass -tags=nosshd at build time
+// to link the [ssh_disabled.go] stub instead, which keeps
+// golang.org/x/crypto/ssh out of the dependency graph.
+func bringUpSSH(logger *slog.Logger, cfg *config, envVars []string) (func(), error) {
+	if cfg.disableSSH {
+		logger.Info("SSH bring-up disabled via WithoutSSH")
+		return func() {}, nil
+	}
+
+	authorizedKeys, err := ParseAuthorizedKeys(cfg.sshKeysPath)
+	if err != nil {
+		return nil, fmt.Errorf("parsing authorized keys: %w", err)
+	}
+
+	// Load injected host key (if present). The key is deleted from disk
+	// after loading into memory so it cannot be read by the sandbox user.
+	// If the file does not exist, hostKeySigner remains nil and the SSH
+	// server will generate an ephemeral key.
+	var hostKeySigner ssh.Signer
+	if hostKeyPEM, readErr := os.ReadFile(cfg.sshHostKeyPath); readErr == nil {
+		signer, parseErr := ssh.ParsePrivateKey(hostKeyPEM)
+		if parseErr != nil {
+			logger.Warn("failed to parse injected host key, falling back to ephemeral",
+				"path", cfg.sshHostKeyPath, "error", parseErr)
+		} else {
+			hostKeySigner = signer
+			logger.Info("loaded injected SSH host key", "path", cfg.sshHostKeyPath)
+		}
+		_ = os.Remove(cfg.sshHostKeyPath)
+	}
+
+	sshdCfg := sshd.Config{
+		Port:            cfg.sshPort,
+		AuthorizedKeys:  authorizedKeys,
+		Env:             envVars,
+		DefaultUID:      cfg.userUID,
+		DefaultGID:      cfg.userGID,
+		DefaultUser:     cfg.userName,
+		DefaultHome:     cfg.userHome,
+		DefaultShell:    cfg.userShell,
+		DefaultWorkDir:  cfg.workspaceMountPoint,
+		AgentForwarding: cfg.sshAgentForwarding,
+		HostKey:         hostKeySigner,
+		Logger:          logger,
+	}
+	srv, err := sshd.New(sshdCfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating SSH server: %w", err)
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.sshPort))
+	if err != nil {
+		return nil, fmt.Errorf("listening on port %d: %w", cfg.sshPort, err)
+	}
+
+	go func() {
+		if err := srv.Serve(ln); err != nil {
+			logger.Error("SSH server error", "error", err)
+		}
+	}()
+
+	logger.Info("SSH server listening", "port", cfg.sshPort)
+	return func() { srv.Close() }, nil
+}
+
+// ParseAuthorizedKeys reads an authorized_keys file and returns the parsed
+// public keys. Returns an error if no valid keys are found.
+//
+// Not available in -tags=nosshd builds (which exclude this file from
+// the dependency graph).
+func ParseAuthorizedKeys(path string) ([]ssh.PublicKey, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var keys []ssh.PublicKey
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+		key, _, _, _, err := ssh.ParseAuthorizedKey(line)
+		if err != nil {
+			continue // skip unparseable lines
+		}
+		keys = append(keys, key)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("no valid keys found in %s", path)
+	}
+	return keys, nil
+}

--- a/guest/boot/ssh_enabled_test.go
+++ b/guest/boot/ssh_enabled_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && !nosshd
+
+package boot
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestParseAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid key", func(t *testing.T) {
+		t.Parallel()
+		_, pubKeyStr := generateTestKey(t)
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "authorized_keys")
+		require.NoError(t, os.WriteFile(path, []byte(pubKeyStr+"\n"), 0o600))
+
+		keys, err := ParseAuthorizedKeys(path)
+		require.NoError(t, err)
+		assert.Len(t, keys, 1)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseAuthorizedKeys("/nonexistent/authorized_keys")
+		assert.Error(t, err)
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "authorized_keys")
+		require.NoError(t, os.WriteFile(path, []byte(""), 0o600))
+
+		_, err := ParseAuthorizedKeys(path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no valid keys")
+	})
+
+	t.Run("invalid key skipped", func(t *testing.T) {
+		t.Parallel()
+		_, pubKeyStr := generateTestKey(t)
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "authorized_keys")
+		content := "not-a-valid-key\n" + pubKeyStr + "\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		keys, err := ParseAuthorizedKeys(path)
+		require.NoError(t, err)
+		assert.Len(t, keys, 1)
+	})
+
+	t.Run("comments skipped", func(t *testing.T) {
+		t.Parallel()
+		_, pubKeyStr := generateTestKey(t)
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "authorized_keys")
+		content := "# comment\n" + pubKeyStr + "\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		keys, err := ParseAuthorizedKeys(path)
+		require.NoError(t, err)
+		assert.Len(t, keys, 1)
+	})
+}
+
+func TestBringUpSSH_DisabledIsNoOp(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	cfg.disableSSH = true
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	shutdown, err := bringUpSSH(logger, cfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+	shutdown() // must not panic
+}
+
+// generateTestKey creates an ECDSA key pair and returns the signer and
+// the authorized_keys-formatted public key string.
+func generateTestKey(t *testing.T) (ssh.Signer, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(key)
+	require.NoError(t, err)
+	pubKeyStr := string(ssh.MarshalAuthorizedKey(signer.PublicKey()))
+	return signer, pubKeyStr
+}

--- a/options.go
+++ b/options.go
@@ -373,6 +373,12 @@ func WithVsock(port uint32, socketPath string) Option {
 // This is purely a guest-side signal: it does not change anything in
 // the host process or runner subprocess. Callers that supply their own
 // guest init binary (e.g. bbox-agent) may choose to ignore the flag.
+//
+// In `guest/boot`, the SSH listener is also build-tag-gated: the SSH
+// path is compiled in by default, and stripped at link time when the
+// init binary is built with -tags=nosshd. Calling WithoutSSH is
+// required when the init binary is built with that tag; otherwise
+// [guest/boot.Run] fails with [guest/boot.ErrSSHNotBuilt].
 func WithoutSSH() Option {
 	return optionFunc(func(c *config) { c.disableSSH = true })
 }


### PR DESCRIPTION
## Summary

Splits `guest/boot` so the SSH-specific code lives behind a
`//go:build nosshd` opt-out tag. The **default build keeps SSH on**
(current behavior, no consumer changes required); passing
`-tags=nosshd` swaps in a stub that drops `golang.org/x/crypto/ssh`
and `guest/sshd` from the link-time graph.

This is the link-time follow-up to #85 (WP-3.1 vsock + runtime
`WithoutSSH`). That PR gave callers a runtime knob to skip the SSH
listener; this one lets opt-out callers also strip the SSH code from
the binary at build time.

## Why opt-out (not opt-in)

The first revision of this PR made SSH **opt-in** via `-tags=sshd`,
which would have required brood-box to update its build before being
able to bump go-microvm. Reviewer feedback (rightly) flagged that as
gratuitously disruptive — there's no reason to flip the default for
the existing consumer. Inverted to opt-out: brood-box needs no
changes, and bbox-k8s adds `-tags=nosshd` to its `bbox-agent` build
when it wants the link-time elimination.

## What's in the PR (one commit)

- `guest/boot/boot.go` no longer imports `golang.org/x/crypto/ssh` or
  `guest/sshd`. The orchestrator now calls a single
  `bringUpSSH(logger, cfg, envVars)` provided by one of two new files.
- `guest/boot/ssh_enabled.go` (`//go:build linux && !nosshd`) — the
  real impl. Owns `ParseAuthorizedKeys`, host-key load, listener start.
  This is what the **default build** links.
- `guest/boot/ssh_disabled.go` (`//go:build linux && nosshd`) — stub.
  No-op when `cfg.disableSSH` is true; returns the new sentinel
  `ErrSSHNotBuilt` when it is false (loud-fail on misconfig).
- Tests split by the same tag:
  - `boot_test.go` — option/config tests (default + nosshd, no SSH types).
  - `ssh_enabled_test.go` (`!nosshd`) — `ParseAuthorizedKeys` + the
    `generateTestKey` helper that depends on `x/crypto/ssh`.
  - `ssh_disabled_test.go` (`nosshd`) — verifies both stub paths
    (no-op vs `ErrSSHNotBuilt`).
- `Taskfile.yaml` — `test`, `test-nocgo`, and `build-nocgo` now run
  both the default and `-tags=nosshd` variants so CI exercises both
  code paths.
- Host-side `microvm.WithoutSSH` doc and the `guest/boot` package doc
  both mention `ErrSSHNotBuilt`.

## Verification

```
$ go list -deps ./guest/boot/                | grep -E "crypto/ssh|guest/sshd"
golang.org/x/crypto/ssh
golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
github.com/stacklok/go-microvm/guest/sshd

$ go list -tags=nosshd -deps ./guest/boot/   | grep -E "crypto/ssh|guest/sshd"
(empty)
```

A small `boot.Run`-importing test binary built two ways:

| Build              | Size  | `crypto/ssh` + `guest/sshd` symbols (`go tool nm`) |
|--------------------|-------|----------------------------------------------------|
| default            | 7.5 M | 518                                                |
| `-tags=nosshd`     | 4.0 M | 0                                                  |

## Consumer impact

- **brood-box** — no change required. The `cmd/bbox-init` build
  continues to work without any tag.
- **bbox-k8s** — no source change required (`cmd/bbox-agent` already
  calls `boot.WithoutSSH()`). After bumping to the release containing
  this change, add `-tags=nosshd` to the `bbox-agent` build to actually
  strip the SSH code from the binary. Without that tag, the binary
  works correctly (`WithoutSSH` still suppresses the listener at
  runtime) but still links the SSH code — same as today.

## Test plan

- [x] `task fmt` — clean
- [x] `task lint` — 0 issues
- [x] `task test-nocgo` — all packages pass under both default and
      `-tags=nosshd`
- [x] `go list -deps` confirms `crypto/ssh` present by default,
      absent with `-tags=nosshd`
- [x] Binary-level `go tool nm`: 0 SSH symbols with `-tags=nosshd`,
      518 in the default build
- [ ] CI: confirms both variants pass on the runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)