### PR TITLE
Fix OCI extractor: allow symlink to replace directory in rootfs

### DIFF
--- a/image/pull.go
+++ b/image/pull.go
@@ -417,9 +417,18 @@ func applyLayerToDir(layerDir, dst string) error {
 			// Remove any existing entry at target.
 			if existing, err := os.Lstat(target); err == nil {
 				if existing.IsDir() {
-					return fmt.Errorf("refusing to replace directory with symlink: %s", target)
+					// mutate.Extract squashes layers newest-first: a newer layer's directory
+					// entry (e.g. /var/run/ from ko's tool layer) arrives before an older
+					// base layer's symlink (e.g. var/run -> ../run from wolfi/chainguard).
+					// Wolfi/chainguard intentionally uses this symlink for FHS compatibility,
+					// so replacing the directory tree with it is correct. The symlink target
+					// has already been validated to stay within the rootfs above.
+					if err := os.RemoveAll(target); err != nil {
+						return fmt.Errorf("remove %s before replacing with symlink: %w", target, err)
+					}
+				} else {
+					_ = os.Remove(target)
 				}
-				_ = os.Remove(target)
 			}
 			if err := os.Symlink(linkTarget, target); err != nil {
 				return fmt.Errorf("create symlink %s: %w", rel, err)
@@ -801,15 +810,13 @@ func extractSymlink(hdr *tar.Header, target, rootDir string) error {
 		}
 	}
 
-	// Check if the target is an existing directory -- refuse to replace
-	// directories with symlinks.
-	if info, err := os.Lstat(target); err == nil {
-		if info.IsDir() {
-			return fmt.Errorf("refusing to replace directory with symlink: %s", target)
-		}
-		_ = os.Remove(target)
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat symlink target %s: %w", target, err)
+	// Remove any existing entry at target. A directory may already exist here
+	// when ko (or similar tools) placed subdirectories under var/run before the
+	// wolfi/chainguard base layer's var/run -> ../run symlink is applied. The
+	// symlink target has already been validated to stay within the rootfs above.
+	// RemoveAll is a no-op if the path does not exist, so no pre-check is needed.
+	if err := os.RemoveAll(target); err != nil {
+		return fmt.Errorf("remove %s before replacing with symlink: %w", target, err)
 	}
 
 	if err := os.Symlink(linkTarget, target); err != nil {

--- a/image/pull_test.go
+++ b/image/pull_test.go
@@ -750,21 +750,59 @@ func TestExtractSymlink_ReplacesExistingFile(t *testing.T) {
 	assert.Equal(t, "real content", string(data))
 }
 
-func TestExtractSymlink_RefusesToReplaceDirectory(t *testing.T) {
+func TestExtractSymlink_ReplacesDirectory(t *testing.T) {
 	t.Parallel()
 
 	dst := t.TempDir()
 
-	// Create a directory first, then attempt to replace it with a symlink.
+	// mutate.Extract squashes layers newest-first, so a tool layer's directory
+	// entry can arrive before the base layer's symlink at the same path (e.g.
+	// var/run -> ../run from wolfi/chainguard). The extractor must replace the
+	// directory -- including its contents -- with the symlink.
 	entries := []tarEntry{
 		{name: "mydir/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "mydir/inner.txt", typeflag: tar.TypeReg, mode: 0o644, content: "stale"},
+		{name: "somewhere", typeflag: tar.TypeReg, mode: 0o644, content: "real content"},
 		{name: "mydir", typeflag: tar.TypeSymlink, mode: 0o777, linkname: "somewhere"},
 	}
 	buf := createTarBuffer(t, entries)
 
 	err := extractTar(context.Background(), buf, dst)
+	require.NoError(t, err)
+
+	linkTarget, err := os.Readlink(filepath.Join(dst, "mydir"))
+	require.NoError(t, err)
+	assert.Equal(t, "somewhere", linkTarget)
+
+	// mydir now resolves through the symlink to the "somewhere" regular file,
+	// so looking up mydir/inner.txt fails outright -- the stale directory and
+	// its contents are gone.
+	_, err = os.Lstat(filepath.Join(dst, "mydir", "inner.txt"))
+	assert.Error(t, err)
+}
+
+func TestExtractSymlink_EscapeAttemptRefusedEvenOverDirectory(t *testing.T) {
+	t.Parallel()
+
+	dst := t.TempDir()
+
+	// A directory must not be removed unless the replacing symlink's target
+	// has already been validated to stay within the rootfs.
+	entries := []tarEntry{
+		{name: "mydir/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "mydir/inner.txt", typeflag: tar.TypeReg, mode: 0o644, content: "kept"},
+		{name: "mydir", typeflag: tar.TypeSymlink, mode: 0o777, linkname: "../../../../../../etc/passwd"},
+	}
+	buf := createTarBuffer(t, entries)
+
+	err := extractTar(context.Background(), buf, dst)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "refusing to replace directory with symlink")
+	assert.Contains(t, err.Error(), "points outside rootfs")
+
+	// The directory and its contents must survive the refused replacement.
+	data, err := os.ReadFile(filepath.Join(dst, "mydir", "inner.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "kept", string(data))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `mutate.Extract` (go-containerregistry) squashes layers newest-first, so a tool layer's directory entry (e.g. `/var/run/` added by ko) arrives before the base layer's symlink (e.g. `var/run -> ../run` from wolfi/chainguard). The extractor was hard-refusing this transition with a policy error.
- Fix: use `os.RemoveAll` to clear the existing directory before creating the symlink, but only **after** the symlink target has been validated to stay within the rootfs. This preserves the path-traversal safety guarantee.
- Same fix applied to both the flat extractor (`applyLayerToDir`) and the layered extractor (`extractSymlink`).
- Error messages updated to wrap the underlying OS error (`%w`) and describe the actual failure rather than the old policy-refusal wording.

## Reproduction

Build a Go binary with ko on top of a wolfi/chainguard base image. ko adds a `/var/run/ko/` metadata directory in its layer. When go-microvm extracts that image to a flat rootfs, it would fail with:

```
extract "var/run": refusing to replace directory with symlink
```

## Test plan

- [ ] Build a ko image using `ghcr.io/stacklok/brood-box/base:latest` (wolfi) as base
- [ ] Confirm go-microvm extracts it without error
- [ ] Confirm `var/run -> ../run` symlink is present in the extracted rootfs
- [ ] Confirm existing unit tests pass (`go test ./image/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)