### PR TITLE
Build builder image in CI when tag is missing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,9 +91,18 @@ jobs:
   build-cgo-linux:
     name: Build (Linux CGO)
     runs-on: ubuntu-latest
+    env:
+      # Force docker so the manifest check, local build, and build-runner
+      # all use the same container storage. GitHub runners have docker.
+      CONTAINER_RUNTIME: docker
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Source versions.env
+        run: |
+          source versions.env
+          echo "LIBKRUN_VERSION=${LIBKRUN_VERSION}" >> "$GITHUB_ENV"
 
       - name: Set up Task
         uses: arduino/setup-task@v3.0.0
@@ -107,6 +116,23 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The builder image is tagged by LIBKRUN_VERSION. When a PR bumps
+      # LIBKRUN_VERSION, the image for that tag doesn't exist yet (it's
+      # built by builder.yaml only after merge to main). Check the registry
+      # and build locally if missing so CI can verify the bump.
+      - name: Check if builder image exists
+        id: check-builder
+        run: |
+          if docker manifest inspect ghcr.io/stacklok/go-microvm-builder:${LIBKRUN_VERSION} >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build builder image locally
+        if: steps.check-builder.outputs.exists == 'false'
+        run: task builder-image-build
 
       - name: Build runner using builder container
         run: task build-runner


### PR DESCRIPTION
## Problem

The Renovate PR that bumps `LIBKRUN_VERSION` (#107 → v1.19.4) fails the `Build (Linux CGO)` check with:
```
Error: reading manifest v1.19.4 in ghcr.io/stacklok/go-microvm-builder: manifest unknown
```

The builder image is tagged by `LIBKRUN_VERSION` and only built by `builder.yaml` **after merge to main**. When a PR bumps `LIBKRUN_VERSION`, the image for the new tag doesn't exist yet, so `task build-runner` fails pulling it — a chicken-and-egg problem.

## Fix

Add a registry check in the `Build (Linux CGO)` job:
- If `ghcr.io/stacklok/go-microvm-builder:<LIBKRUN_VERSION>` exists → pull as before (fast path; applies to all normal PRs and libkrunfw-only bumps).
- If it doesn't exist → build it locally via `task builder-image-build` so CI can verify the bump (only happens when `LIBKRUN_VERSION` actually changes).

`CONTAINER_RUNTIME=docker` is forced for the job so the manifest check, local build, and `build-runner` all share the same container storage (GitHub runners have docker; the Taskfile default prefers podman, which would use separate storage).

## Scoping

This only triggers for libkrun version bumps, not libkrunfw bumps or unrelated PRs — `BUILDER_IMAGE_TAG` is derived from `LIBKRUN_VERSION` only (`Taskfile.yaml:32`), so libkrunfw-only PRs like #108 reuse the existing builder image and take the fast path.

Follow-up to #106.