### PR TITLE
Enforce read-only virtiofs on host

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,10 @@ func main() {
             return sshClient.WaitForReady(ctx)
         }),
 
-        // Mount a host directory into the guest via virtio-fs.
+        // Mount a host directory into the guest via virtio-fs. ReadOnly
+        // requests both host-side libkrun enforcement and a guest MS_RDONLY mount.
         microvm.WithVirtioFS(microvm.VirtioFSMount{
-            Tag: "shared", HostPath: "/srv/data",
+            Tag: "shared", HostPath: "/srv/data", ReadOnly: true,
         }),
 
         // Use a custom data directory for state, caches, and logs.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,7 @@ go-microvm solves this with two processes:
 |   4. Run rootfs hooks            | config|   4. SetVMConfig(vCPUs, RAM)      |
 |   5. Write .krun_config.json     |       |   5. SetRoot(rootfsPath)          |
 |   6. Start networking (if custom)|       |   6. Setup networking             |
-|   7. Spawn go-microvm-runner       |       |   7. AddVirtioFS (for each mount) |
+|   7. Spawn go-microvm-runner       |       |   7. Add virtio-fs mounts          |
 |   8. Run post-boot hooks         |       |   8. SetConsoleOutput(logPath)    |
 |   9. Return *VM handle           |       |   9. krun_start_enter()           |
 |                                  |       |      (NEVER RETURNS ON SUCCESS)   |
@@ -115,7 +115,8 @@ C API:
    - If `NetSockPath` is set (custom provider), connect via `AddNetUnixStream()`
    - If `PortForwards` is set (default path), create an in-process
      VirtualNetwork with a socketpair and pass the VM-side fd to libkrun
-7. Add virtio-fs mounts via `AddVirtioFS()` (for each mount)
+7. Add virtio-fs mounts via legacy `AddVirtioFS()` for read-write mounts or
+   `AddVirtioFS3(..., readOnly=true)` for host-enforced read-only mounts
 8. Set console output via `SetConsoleOutput()` (if log path provided)
 9. Call `krun_start_enter()` which takes over the process
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -430,6 +430,19 @@ sending signals:
 This prevents sending signals to unrelated processes if the PID has
 been reused.
 
+## Read-only virtio-fs mounts
+
+`VirtioFSMount.ReadOnly` is enforced independently on both sides of the VM
+boundary. The runner uses libkrun's `krun_add_virtiofs3(..., read_only=true)` so
+the host virtio-fs device rejects writes, while guest initialization also mounts
+the filesystem with `MS_RDONLY`. The guest mount flag is defense in depth, not
+the security boundary.
+
+Read-write mounts continue to use the legacy `krun_add_virtiofs` API. Read-only
+mounts require the pinned libkrun v1.19.4 API and never fall back to guest-only
+enforcement: a missing symbol prevents the runner from loading, and an API error
+aborts configuration before `krun_start_enter()` starts the VM.
+
 ## Host Capabilities (Linux)
 
 When running as a non-root user on Linux, go-microvm requires `CAP_CHOWN` on the

--- a/krun/context.go
+++ b/krun/context.go
@@ -171,7 +171,7 @@ func (c *Context) AddDisk2(blockID, diskPath string, format DiskFormat, readOnly
 	return nil
 }
 
-// AddVirtioFS adds a virtio-fs device pointing to a host directory.
+// AddVirtioFS adds a read-write virtio-fs device pointing to a host directory.
 func (c *Context) AddVirtioFS(tag, path string) error {
 	cTag := C.CString(tag)
 	defer C.free(unsafe.Pointer(cTag))
@@ -182,6 +182,22 @@ func (c *Context) AddVirtioFS(tag, path string) error {
 	ret := C.krun_add_virtiofs(c.id, cTag, cPath)
 	if ret < 0 {
 		return fmt.Errorf("krun_add_virtiofs failed: %d", ret)
+	}
+	return nil
+}
+
+// AddVirtioFS3 adds a virtio-fs device with an explicit DAX window size and
+// host-enforced read-only setting.
+func (c *Context) AddVirtioFS3(tag, path string, shmSize uint64, readOnly bool) error {
+	cTag := C.CString(tag)
+	defer C.free(unsafe.Pointer(cTag))
+
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ret := C.krun_add_virtiofs3(c.id, cTag, cPath, C.uint64_t(shmSize), C.bool(readOnly))
+	if ret < 0 {
+		return fmt.Errorf("krun_add_virtiofs3 failed: %d", ret)
 	}
 	return nil
 }

--- a/options.go
+++ b/options.go
@@ -56,10 +56,11 @@ type VsockPort struct {
 type VirtioFSMount struct {
 	Tag      string
 	HostPath string
-	// ReadOnly makes the mount read-only inside the guest. Enforcement is
-	// guest-side via MS_RDONLY mount flags; libkrun does not currently
-	// support host-side read-only virtiofs. A compromised guest kernel
-	// could bypass this restriction.
+	// ReadOnly makes the mount read-only at two independent layers: libkrun
+	// exposes the host directory through a read-only virtio-fs device, and the
+	// guest mounts it with MS_RDONLY. This requires the pinned libkrun runtime's
+	// krun_add_virtiofs3 API; the runner fails before VM start if it is unavailable
+	// or rejects the configuration.
 	ReadOnly bool
 	// OverrideUID, when > 0, causes go-microvm to set the
 	// user.containers.override_stat xattr on every file and directory under

--- a/runner/cmd/go-microvm-runner/main.go
+++ b/runner/cmd/go-microvm-runner/main.go
@@ -82,7 +82,8 @@ type VirtioFSMount struct {
 	Tag string `json:"tag"`
 	// Path is the host directory path.
 	Path string `json:"path"`
-	// ReadOnly makes the mount read-only inside the guest.
+	// ReadOnly makes the mount read-only both at the host virtio-fs device
+	// boundary and through the guest's MS_RDONLY mount flag.
 	ReadOnly bool `json:"read_only,omitempty"`
 }
 
@@ -212,14 +213,10 @@ func runVM(config *Config) error {
 		}
 	}
 
-	// Configure virtio-fs mounts.
-	// Note: libkrun's krun_add_virtiofs does not support a read-only flag.
-	// ReadOnly enforcement happens guest-side via MS_RDONLY mount flags.
+	// Configure virtio-fs mounts. Read-write mounts retain the legacy API;
+	// read-only mounts require krun_add_virtiofs3 for host-side enforcement.
 	for _, mount := range config.VirtioFSMounts {
-		if mount.ReadOnly {
-			fmt.Fprintf(os.Stderr, "Warning: virtiofs mount %q is read-only but libkrun has no host-side enforcement; relying on guest-side MS_RDONLY\n", mount.Tag)
-		}
-		if err := ctx.AddVirtioFS(mount.Tag, mount.Path); err != nil {
+		if err := addVirtioFSMount(ctx, mount); err != nil {
 			_ = ctx.Free()
 			return fmt.Errorf("add virtiofs mount %s: %w", mount.Tag, err)
 		}

--- a/runner/cmd/go-microvm-runner/virtiofs.go
+++ b/runner/cmd/go-microvm-runner/virtiofs.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build (linux || darwin) && cgo
+
+package main
+
+type virtioFSMounter interface {
+	AddVirtioFS(tag, path string) error
+	AddVirtioFS3(tag, path string, shmSize uint64, readOnly bool) error
+}
+
+func addVirtioFSMount(ctx virtioFSMounter, mount VirtioFSMount) error {
+	if mount.ReadOnly {
+		return ctx.AddVirtioFS3(mount.Tag, mount.Path, 0, true)
+	}
+	return ctx.AddVirtioFS(mount.Tag, mount.Path)
+}

--- a/runner/cmd/go-microvm-runner/virtiofs_test.go
+++ b/runner/cmd/go-microvm-runner/virtiofs_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build (linux || darwin) && cgo
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type recordingVirtioFSMounter struct {
+	legacyCalls []VirtioFSMount
+	v3Calls     []virtioFS3Call
+	v3Err       error
+}
+
+type virtioFS3Call struct {
+	mount   VirtioFSMount
+	shmSize uint64
+}
+
+func (r *recordingVirtioFSMounter) AddVirtioFS(tag, path string) error {
+	r.legacyCalls = append(r.legacyCalls, VirtioFSMount{Tag: tag, Path: path})
+	return nil
+}
+
+func (r *recordingVirtioFSMounter) AddVirtioFS3(tag, path string, shmSize uint64, readOnly bool) error {
+	r.v3Calls = append(r.v3Calls, virtioFS3Call{
+		mount:   VirtioFSMount{Tag: tag, Path: path, ReadOnly: readOnly},
+		shmSize: shmSize,
+	})
+	return r.v3Err
+}
+
+func TestVirtioFSMountJSONSelectsHostEnforcement(t *testing.T) {
+	t.Parallel()
+
+	var cfg Config
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"root_path":"/rootfs",
+		"num_vcpus":1,
+		"ram_mib":512,
+		"virtiofs_mounts":[
+			{"tag":"rw","path":"/host/rw"},
+			{"tag":"ro","path":"/host/ro","read_only":true}
+		]
+	}`), &cfg))
+	require.Len(t, cfg.VirtioFSMounts, 2)
+
+	recorder := &recordingVirtioFSMounter{}
+	for _, mount := range cfg.VirtioFSMounts {
+		require.NoError(t, addVirtioFSMount(recorder, mount))
+	}
+
+	require.Equal(t, []VirtioFSMount{{Tag: "rw", Path: "/host/rw"}}, recorder.legacyCalls)
+	require.Equal(t, []virtioFS3Call{{
+		mount:   VirtioFSMount{Tag: "ro", Path: "/host/ro", ReadOnly: true},
+		shmSize: 0,
+	}}, recorder.v3Calls)
+}
+
+func TestReadOnlyVirtioFSMountDoesNotDowngrade(t *testing.T) {
+	t.Parallel()
+
+	apiErr := errors.New("krun_add_virtiofs3 incompatible")
+	recorder := &recordingVirtioFSMounter{v3Err: apiErr}
+
+	err := addVirtioFSMount(recorder, VirtioFSMount{Tag: "ro", Path: "/host/ro", ReadOnly: true})
+	require.ErrorIs(t, err, apiErr)
+	require.Empty(t, recorder.legacyCalls)
+	require.Len(t, recorder.v3Calls, 1)
+}

--- a/runner/config.go
+++ b/runner/config.go
@@ -73,6 +73,7 @@ type VirtioFSMount struct {
 	Tag string `json:"tag"`
 	// HostPath is the host directory path.
 	HostPath string `json:"path"`
-	// ReadOnly makes the mount read-only inside the guest.
+	// ReadOnly makes the mount read-only both at the host virtio-fs device
+	// boundary and through the guest's MS_RDONLY mount flag.
 	ReadOnly bool `json:"read_only,omitempty"`
 }


### PR DESCRIPTION
## Summary

- carry `VirtioFSMount.ReadOnly` through both runner config representations
- use libkrun v1.19.4 `krun_add_virtiofs3` for host-enforced read-only mounts
- preserve the legacy read-write path and fail closed instead of downgrading read-only enforcement
- document the host/guest enforcement boundary

## Verification

- `task fmt`
- `task lint`
- `task test`
- `task test-nocgo`
- `task build-nocgo`
- `task build-runner` against pinned libkrun v1.19.4
- secure-code review: SHIP

Closes #120

Blocks stacklok/mecatl#526 until released and consumed.